### PR TITLE
settings: Add local_settings support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 .coverage*
 .DS_Store
+/local_settings.py
 /.env
 /.venv
 /.cache/

--- a/mvj/settings.py
+++ b/mvj/settings.py
@@ -117,3 +117,9 @@ REST_FRAMEWORK = {
         'django_filters.rest_framework.DjangoFilterBackend',
     ],
 }
+
+local_settings = project_root('local_settings.py')
+if os.path.exists(local_settings):
+    with open(local_settings) as fp:
+        code = compile(fp.read(), local_settings, 'exec')
+    exec(code, globals(), locals())


### PR DESCRIPTION
If local_settings.py is found in the project root, execute it in the
context of the settings module to allow defining local settings via
Python code too.