### PR TITLE
Add legacy importer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
   global:
     - SECRET_KEY=xxx
     - DATABASE_URL=postgis://postgres:@localhost/mvj
+    - LEGACY_USER=''
+    - LEGACY_PASSWORD=''
+    - LEGACY_HOST=''
+    - LEGACY_PORT=''
+    - LEGACY_SERVICES=''
 
 python:
   - "3.4"

--- a/leasing/integrations/legacy.py
+++ b/leasing/integrations/legacy.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+
+import cx_Oracle
+from leasing.models import Lease
+
+
+def get_cursor():
+    dsn_tns = cx_Oracle.makedsn(
+        settings.LEGACY_HOST,
+        settings.LEGACY_PORT,
+        settings.LEGACY_SERVICES,
+    )
+
+    connection = cx_Oracle.connect(
+        user=settings.LEGACY_USER,
+        password=settings.LEGACY_PASSWORD,
+        dsn=dsn_tns,
+    )
+    return connection.cursor()
+
+
+def import_table(importer, table_name):
+    cursor = get_cursor()
+    cursor.execute("SELECT count(*) FROM %s" % table_name)
+    total = cursor.fetchone()[0]
+    cursor.execute("SELECT * FROM %s" % table_name)
+    i = 0
+
+    for row in cursor:
+        importer(row)
+        i += 1
+        percent = round(i/total*100, 1)
+        print('Importing', table_name, str(percent) + '%\r', end='')
+    print('')
+
+
+def import_lease(row):
+    lease, created = Lease.objects.get_or_create(
+        type=row[0],
+        municipality=row[1],
+        district=row[2],
+        # row[3] skipped on purpose
+        sequence=row[4],
+        start_date=row[15],
+        end_date=row[16],
+    )
+    return lease
+
+
+IMPORTERS_AND_TABLE_NAMES = [
+    (import_lease, 'vuokraus'),
+]
+
+
+def run_import():
+    for method, table_name in IMPORTERS_AND_TABLE_NAMES:
+        import_table(method, table_name)

--- a/leasing/management/commands/legacy_import.py
+++ b/leasing/management/commands/legacy_import.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from leasing.integrations.legacy import run_import
+
+
+class Command(BaseCommand):
+    help = 'Script for importing from the legacy database'
+
+    def handle(self, *args, **options):
+        run_import()

--- a/mvj/settings.py
+++ b/mvj/settings.py
@@ -24,6 +24,12 @@ env_file = project_root('.env')
 if os.path.exists(env_file):
     env.read_env(env_file)
 
+LEGACY_USER = env.str('LEGACY_USER')
+LEGACY_PASSWORD = env.str('LEGACY_PASSWORD')
+LEGACY_HOST = env.str('LEGACY_HOST')
+LEGACY_PORT = env.str('LEGACY_PORT')
+LEGACY_SERVICES = env.str('LEGACY_SERVICES')
+
 DEBUG = env.bool('DEBUG')
 SECRET_KEY = env.str('SECRET_KEY', default=('xxx' if DEBUG else ''))
 


### PR DESCRIPTION
Add legacy importer script that connects to the legacy oracle database
and imports data from a table and creates lease objects. Supports adding
more importer/table-pairs.