### PR TITLE
Upgrade Sentry SDK from raven -> sentry_sdk

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,6 +25,6 @@ psycopg2-binary
 pysftp
 python-daemon
 python-dateutil
-raven
+sentry-sdk
 requests
 zeep

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ attrs==19.1.0             # via zeep
 bcrypt==3.1.6             # via paramiko
 beautifulsoup4==4.7.1
 cached-property==1.5.1    # via zeep
-certifi==2019.3.9         # via requests
+certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
@@ -58,16 +58,16 @@ python-dateutil==2.6.0
 python-docx==0.8.7        # via docxtpl
 python-jose==3.0.1        # via django-helusers
 pytz==2019.1              # via django, zeep
-raven==6.10.0
 requests==2.22.0
 requests-toolbelt==0.9.1  # via zeep
 rsa==4.0                  # via python-jose
+sentry-sdk==0.9.2
 simplejson==3.16.0        # via django-rest-swagger
 six==1.12.0               # via bcrypt, cryptography, docxtpl, isodate, pyjwkest, pynacl, python-dateutil, python-jose, zeep
 soupsieve==1.9.1          # via beautifulsoup4
 sqlparse==0.3.0           # via django
 uritemplate==3.0.0        # via coreapi
-urllib3==1.25.3           # via requests
+urllib3==1.25.3           # via requests, sentry-sdk
 zeep==3.3.1
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Older raven SDK has problems with SSL connections while sentry_sdk works
without complaints. Good reason for switchover.

The new SDK also logs any Python logger messages of severity ERROR or
higher to sentry. This is generally useful.

This PR also changes the revision sent to sentry from the bare commit hash
to {latest_tag}-{commits_on_top_of_the_tag}-{short_hash}. This is a
bit more useful than the base hash. Additionally, if no repo is found,
we look in ../service_state/deployed_version as fallback. City of Helsinki
ansibles write the deployed code version therein.