### PR TITLE
Set the state of 0€ invoices to PAID, not OPEN

### DIFF
--- a/leasing/models/invoice.py
+++ b/leasing/models/invoice.py
@@ -285,8 +285,8 @@ class Invoice(TimeStampedSafeDeleteModel):
             Decimal(0),
             self.billed_amount + collection_charge - payments_total - total_credited_amount
         )
-
-        if total_credited_amount.compare(self.billed_amount) != Decimal(-1):
+        # Don't mark as refunded unless credited amount is nonzero
+        if total_credited_amount != Decimal(0) and total_credited_amount.compare(self.billed_amount) != Decimal(-1):
             self.state = InvoiceState.REFUNDED
         elif self.type == InvoiceType.CHARGE and self.outstanding_amount == Decimal(0):
             self.state = InvoiceState.PAID

--- a/leasing/serializers/invoice.py
+++ b/leasing/serializers/invoice.py
@@ -199,6 +199,7 @@ class InvoiceCreateSerializer(UpdateNestedMixin, EnumSupportSerializerMixin, Fie
 
         invoice.invoicing_date = timezone.now().date()
         invoice.outstanding_amount = validated_data['total_amount']
+        invoice.update_amounts()  # 0€ invoice would stay OPEN otherwise
         invoice.save()
 
         return invoice


### PR DESCRIPTION
Refs [#826](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/us/862)

When creating an invoice, the state is set to open by default. However, it's sometimes necessary to create invoices that have a total sum of 0€ (either with a row of amount 0 or pairs of rows with opposite amounts, i.e. 100 and -100). These will not get sent out, so they won't get payments and thus won't be updated, so they should be marked as paid on creation.