### PR TITLE
Docker configuration changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 services:
     postgres:
         build: ./docker/postgres/
@@ -28,7 +28,12 @@ services:
         depends_on:
             - postgres
         container_name: mvj
+        restart: unless-stopped
 
 volumes:
         mvj-postgres-data-volume:
         mvj-django-media-volume:
+networks:
+    default:
+        name: helsinki
+


### PR DESCRIPTION
Set network name to helsinki for docker. This is needed to be compatible with infra version of tunnistamo.
Add restart option to unless-stopped that the container does not stop every time there is some error.
