### PR TITLE
Remove area unit required extra kwarg in LeaseBasisOfRent

### DIFF
--- a/leasing/serializers/rent.py
+++ b/leasing/serializers/rent.py
@@ -393,4 +393,3 @@ class LeaseBasisOfRentCreateUpdateSerializer(LeaseBaseBasisOfRentCreateUpdateSer
                   'discount_percentage', 'plans_inspected_at', 'locked_at', 'archived_at', 'archived_note',
                   'subvention_type', 'subvention_base_percent', 'subvention_graduated_percent',
                   'management_subventions', 'temporary_subventions', 'zone', 'type', 'children')
-        extra_kwargs = {'area_unit': {'required': True}}


### PR DESCRIPTION
Hotfix for not being able to save rents because `area_unit` field for `LeaseBasisOfRent` is expected in the payload. Unless that field was modified, it will not be included (UI sends a PATCH). 

This PR reverts to allowing LeaseBasisOfRents without area unit to be created, so need this needs to be fixed later, but this is more acceptable than not being able to create new rents.