### PR TITLE
Render primary address in laske export document

### DIFF
--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -38,7 +38,13 @@ class InvoiceSalesOrderAdapter:
         first_lease_area = self.invoice.lease.lease_areas.first()
         if first_lease_area:
             real_property_identifier = first_lease_area.identifier
-            lease_area_address = first_lease_area.addresses.first()
+            first_primary_address = first_lease_area.addresses.filter(is_primary=True).first()
+
+            if first_primary_address:
+                lease_area_address = first_primary_address
+            else:
+                lease_area_address = first_lease_area.addresses.first()
+
             if lease_area_address:
                 address = lease_area_address.address
 


### PR DESCRIPTION
Refs [Taiga #923](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/us/923)

Invoices should always show the primary address of a lease area, instead of the currently shown first address, which might or might not be the primary address.

There are some (~100) lease areas which have either 0 or multiple primary addresses. In these cases we take the `.first()` from those querysets (the first from any related addresses or the first primary address, respectively).