### PR TITLE
Update state of invoices after done generating

### DIFF
--- a/leasing/management/commands/create_invoices.py
+++ b/leasing/management/commands/create_invoices.py
@@ -1,10 +1,12 @@
 import datetime
+from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.db.models import Q
 
+from leasing.enums import InvoiceState
 from leasing.models import Invoice, Lease
 from leasing.models.invoice import InvoiceRow, InvoiceSet
 
@@ -78,6 +80,9 @@ class Command(BaseCommand):
                         with transaction.atomic():
                             invoice_data['invoicing_date'] = today
                             invoice_data['outstanding_amount'] = invoice_data['billed_amount']
+                            # ensure 0€ total invoices get marked as PAID
+                            if invoice_data['outstanding_amount'] == Decimal(0):
+                                invoice_data['state'] = InvoiceState.PAID
 
                             invoice = Invoice.objects.create(**invoice_data)
 

--- a/leasing/tests/api/test_create_invoice.py
+++ b/leasing/tests/api/test_create_invoice.py
@@ -7,7 +7,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.urls import reverse
 from django.utils import timezone
 
-from leasing.enums import ContactType, TenantContactType
+from leasing.enums import ContactType, InvoiceState, TenantContactType
 from leasing.models import Invoice
 
 
@@ -44,6 +44,47 @@ def test_create_invoice(django_db_setup, admin_client, lease_factory, tenant_fac
 
     assert invoice.invoicing_date == timezone.now().date()
     assert invoice.outstanding_amount == Decimal(10)
+    assert invoice.state == InvoiceState.OPEN
+
+
+@pytest.mark.django_db
+def test_create_zero_sum_invoice_state_is_paid(django_db_setup, admin_client, lease_factory, tenant_factory,
+                                               tenant_rent_share_factory, contact_factory, tenant_contact_factory):
+    lease = lease_factory(type_id=1, municipality_id=1, district_id=1, notice_period_id=1,
+                          start_date=datetime.date(year=2000, month=1, day=1), is_invoicing_enabled=True)
+
+    tenant1 = tenant_factory(lease=lease, share_numerator=1, share_denominator=1)
+    tenant_rent_share_factory(tenant=tenant1, intended_use_id=1, share_numerator=1, share_denominator=1)
+    contact1 = contact_factory(first_name="First name 1", last_name="Last name 1", type=ContactType.PERSON)
+    tenant_contact_factory(type=TenantContactType.TENANT, tenant=tenant1, contact=contact1,
+                           start_date=datetime.date(year=2000, month=1, day=1))
+
+    data = {
+        'lease': lease.id,
+        'recipient': contact1.id,
+        'due_date': '2019-01-01',
+        'rows': [
+            {
+                'amount': Decimal(10),
+                'receivable_type': 1,
+            },
+            {
+                'amount': Decimal(-10),
+                'receivable_type': 1,
+            }
+        ],
+    }
+
+    url = reverse('invoice-list')
+    response = admin_client.post(url, data=json.dumps(data, cls=DjangoJSONEncoder), content_type='application/json')
+
+    assert response.status_code == 201, '%s %s' % (response.status_code, response.data)
+
+    invoice = Invoice.objects.get(pk=response.data['id'])
+
+    assert invoice.invoicing_date == timezone.now().date()
+    assert invoice.outstanding_amount == Decimal(0)
+    assert invoice.state == InvoiceState.PAID
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
When invoices are generated (monthly) with a management command the rows are created separately. Set the state to PAID if the outstanding amount is 0€ already while creating it.