### PR TITLE
Add management command to prune old JobRunLogEntries

### DIFF
--- a/batchrun/management/commands/drop_old_log_entries.py
+++ b/batchrun/management/commands/drop_old_log_entries.py
@@ -1,0 +1,38 @@
+import argparse
+from typing import Any
+
+from dateutil.relativedelta import relativedelta
+from django.core.management.base import BaseCommand
+
+from ...models import JobRun, JobRunLogEntry
+
+
+class Command(BaseCommand):
+    help = 'JobRunLogEntry cleaner'
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument('retain_n_days', type=int, nargs='?', default=7)
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        retain_n_days = options['retain_n_days']
+
+        latest_run = JobRun.objects.last()
+        if not latest_run:
+            self.stdout.write('No jobruns saved. Exiting...')
+            return
+
+        retain_from = latest_run.started_at - relativedelta(days=retain_n_days)
+        retain_from = retain_from.replace(hour=0, minute=0, second=0, microsecond=0)
+        runs_before_cutoff = JobRun.objects.filter(started_at__lt=retain_from)
+        self.stdout.write(
+            'Latest run started {}, sparing logs from jobs started after {}. JobRuns to delete {}, total {}'.format(
+                latest_run.started_at, retain_from, runs_before_cutoff.count(), JobRun.objects.count()
+            )
+        )
+        log_entries_to_delete = JobRunLogEntry.objects.filter(run__in=runs_before_cutoff)
+        self.stdout.write('Proceeding to delete {} / {} stored JobRunLogEntries'.format(
+            log_entries_to_delete.count(), JobRunLogEntry.objects.count()
+        ))
+        log_entries_to_delete.delete()
+        self.stdout.write('Done!')


### PR DESCRIPTION
Batchrun jobs might generate *a lot* of logs, which all get stored as individual `JobRunLogEntry` objects.

This management command is used to delete old log entries. The setting `retain_n_days` which defaults to 7 is used to control how many days of logs are kept, and are counted backwards from the latest `JobRun`, instead of counting backwards from the current time. This is to ensure that even if no jobs have been run in the last n days, running the command will not accidentally delete all of the logs.