### PR TITLE
Tweak lease statistics report

### DIFF
--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -1,21 +1,25 @@
 import datetime
+from collections import defaultdict
+from decimal import Decimal
+from functools import lru_cache
 
 from django import forms
-from django.db.models import Avg, Q, Sum
+from django.db.models import Q
+from django.utils import formats
 from django.utils.translation import ugettext_lazy as _
-from rest_framework.response import Response
+from enumfields.drf import EnumField
 
-from leasing.enums import LeaseAreaAttachmentType, LeaseState, SubventionType
+from leasing.enums import LeaseAreaAttachmentType, LeaseState, SubventionType, TenantContactType
 from leasing.models import Lease
-from leasing.report.report_base import ReportBase
+from leasing.report.report_base import AsyncReportBase
 
-LIVING = [1, 12, 13]  # TODO: Can we get rid of static ids
+# TODO: Can we get rid of static ids
+RESIDENTIAL_INTENDED_USE_IDS = [1, 12, 13]  # 1 = Asunto, 12 = Asunto, lisärakent., 13 = Asunto 2
+OPTION_TO_PURCHASE_CONDITION_TYPE_ID = 24  # 24 = Osto-optioehto
 
 
 def get_type(obj):
-    if(not obj.state):
-        return
-    return obj.state.value
+    return obj.identifier.type.identifier
 
 
 def get_lease_id(obj):
@@ -23,8 +27,19 @@ def get_lease_id(obj):
 
 
 def get_tenants(obj):
-    now = datetime.date.today()
-    return ', '.join([c.get_name() for c in obj.get_tenant_shares_for_period(now, now)]),
+    today = datetime.date.today()
+
+    contacts = set()
+
+    for tenant in obj.tenants.all():
+        for tc in tenant.tenantcontact_set.all():
+            if tc.type != TenantContactType.TENANT:
+                continue
+
+            if (tc.end_date is None or tc.end_date >= today) and (tc.start_date is None or tc.start_date <= today):
+                contacts.add(tc.contact)
+
+    return ', '.join([c.get_name() for c in contacts])
 
 
 def get_address(obj):
@@ -34,70 +49,65 @@ def get_address(obj):
         if lease_area.archived_at:
             continue
 
-        addresses.extend([la.address for la in lease_area.addresses.filter(is_primary=True)])
+        for area_address in lease_area.addresses.all():
+            if not area_address.is_primary:
+                continue
+
+            addresses.append(area_address.address)
 
     return ' / '.join(addresses)
 
 
-def get_plan_units(obj):
-    return
-    plan_units = []
-
-    for lease_area in obj.lease_areas.all():
-        if lease_area.archived_at:
-            continue
-
-        plan_units.extend(lease_area.plan_unit)
-
-    return ' / '.join(plan_units)
-
-
 def get_supportive_housing(obj):
-    if(not obj.supportive_housing):
+    if not obj.supportive_housing:
         return
     return obj.supportive_housing.name
 
 
 def get_notice_period(obj):
-    if(not obj.notice_period):
+    if not obj.notice_period:
         return
     return obj.notice_period.name
 
 
 def get_district(obj):
-    if(not obj.district):
+    if not obj.district:
         return
     return '{} {}'.format(obj.district.identifier, obj.district.name)
 
 
 def get_preparer(obj):
-    if(not obj.preparer):
+    if not obj.preparer:
         return
     return '{} {}'.format(obj.preparer.last_name, obj.preparer.first_name)
 
 
 def get_form_of_management(obj):
-    if(not obj.management):
+    if not obj.management:
         return
     return obj.management.name
 
 
 def get_lessor(obj):
-    if(not obj.lessor):
+    if not obj.lessor:
         return
     return obj.lessor.name
 
 
 def get_form_of_regulation(obj):
-    if(not obj.regulation):
+    if not obj.regulation:
         return
     return obj.regulation.name
 
 
 def get_contract_number(obj):
     contract_numbers = []
-    for contract in obj.contracts.filter(contract_number__isnull=False).exclude(contract_number=''):
+    for contract in obj.contracts.all():
+        if not contract.contract_number:
+            continue
+
         contract_numbers.append(contract.contract_number)
+
     return ' / '.join(contract_numbers)
 
 
@@ -105,15 +115,20 @@ def get_matti_report(obj):
     for lease_area in obj.lease_areas.all():
         if lease_area.archived_at:
             continue
-        if(lease_area.attachments.filter(type=LeaseAreaAttachmentType.MATTI_REPORT)):
-            return True
+
+        for attachment in lease_area.attachments.all():
+            if attachment.type == LeaseAreaAttachmentType.MATTI_REPORT:
+                return True
+
     return False
 
 
-def get_buy_right(obj):
-    for decisions in obj.decisions.all():
-        if(decisions.conditions.filter(type_id=24)):  # TODO: Can we get rid of static type_id
-            return True
+def get_option_to_purchase(obj):
+    for decision in obj.decisions.all():
+        for condition in decision.conditions.all():
+            if condition.type_id == OPTION_TO_PURCHASE_CONDITION_TYPE_ID:
+                return True
+
     return False
 
 
@@ -129,86 +144,134 @@ def get_lease_area_identifier(obj):
     return ' / '.join(lease_area_identifiers)
 
 
-def get_total_rent_amount_for_year(obj):
-    year = datetime.date.today().year
-    return obj.calculate_rent_amount_for_year(year).get_total_amount()
-
-
 def get_total_area(obj):
-    return obj.lease_areas.aggregate(Sum('area'))['area__sum']
+    total_area = 0
+    for lease_area in obj.lease_areas.all():
+        if lease_area.archived_at:
+            continue
+
+        total_area += lease_area.area
+
+    return total_area
 
 
 def get_re_lease(obj):
     year = datetime.date.today().year
     year_start = datetime.date(year, 1, 1)
     year_end = datetime.date(year, 12, 31)
-    for rent in obj.get_active_rents_on_period(year_start, year_end):
-        if(rent.rent_adjustments.filter(subvention_type=SubventionType.RE_LEASE)):
-            return True
+
+    for rent in obj.rents.all():
+        if (rent.end_date is None or rent.end_date >= year_start) and (
+                rent.start_date is None or rent.start_date <= year_end):
+            for ra in rent.rent_adjustments.all():
+                if ra.subvention_type == SubventionType.RE_LEASE:
+                    return True
+
     return False
 
 
-def get_build_permission_living(obj):
-    qs = obj.basis_of_rents.filter(intended_use__id__in=LIVING).values('area_unit').annotate(area=Sum('area'))
-    return ' / '.join(['{} {}'.format(i.get('area'), i.get('area_unit')) for i in qs])
+def get_permitted_building_volume_residential(obj):
+    volumes = defaultdict(Decimal)
+    for basis_of_rent in obj.basis_of_rents.all():
+        if basis_of_rent.intended_use_id not in RESIDENTIAL_INTENDED_USE_IDS:
+            continue
+
+        volumes[basis_of_rent.area_unit] += basis_of_rent.area
+
+    return ' / '.join(['{} {}'.format(
+        formats.number_format(area, decimal_pos=2, use_l10n=True), area_unit) for area_unit, area in volumes.items()])
 
 
-def get_build_permission_business(obj):
-    qs = obj.basis_of_rents.exclude(intended_use__id__in=LIVING).values('area_unit').annotate(area=Sum('area'))
-    return ' / '.join(['{} {}'.format(i.get('area'), i.get('area_unit')) for i in qs])
+def get_permitted_building_volume_business(obj):
+    volumes = defaultdict(Decimal)
+    for basis_of_rent in obj.basis_of_rents.all():
+        if basis_of_rent.intended_use_id in RESIDENTIAL_INTENDED_USE_IDS:
+            continue
+
+        volumes[basis_of_rent.area_unit] += basis_of_rent.area
+
+    return ' / '.join(['{} {}'.format(
+        formats.number_format(area, decimal_pos=2, use_l10n=True), area_unit) for area_unit, area in volumes.items()])
 
 
-def get_build_permission_total(obj):
-    qs = obj.basis_of_rents.all().values('area_unit').annotate(area=Sum('area'))
-    return ' / '.join(['{} {}'.format(i.get('area'), i.get('area_unit')) for i in qs])
+def get_permitted_building_volume_total(obj):
+    volumes = defaultdict(Decimal)
+    for basis_of_rent in obj.basis_of_rents.all():
+        volumes[basis_of_rent.area_unit] += basis_of_rent.area
+
+    return ' / '.join(['{} {}'.format(
+        formats.number_format(area, decimal_pos=2, use_l10n=True), area_unit) for area_unit, area in volumes.items()])
 
 
-def get_rent_amount_living(obj):
+@lru_cache(maxsize=1)
+def _get_rent_amount_for_year(obj, year):
+    return obj.calculate_rent_amount_for_year(year)
+
+
+def get_rent_amount_residential(obj):
     year = datetime.date.today().year
-    sum = 0
-    for a in obj.calculate_rent_amount_for_year(year).amounts:
-        for tabiu, value in a.get_total_amounts_by_intended_uses().items():
-            if(tabiu.id in LIVING):
-                sum += value
-    return sum
+    total_amount = Decimal(0)
+    for intended_use, amount in _get_rent_amount_for_year(obj, year).get_total_amounts_by_intended_uses().items():
+        if intended_use.id in RESIDENTIAL_INTENDED_USE_IDS:
+            total_amount += amount
+
+    return total_amount
 
 
 def get_rent_amount_business(obj):
     year = datetime.date.today().year
-    sum = 0
-    for a in obj.calculate_rent_amount_for_year(year).amounts:
-        for tabiu, value in a.get_total_amounts_by_intended_uses().items():
-            if(tabiu.id not in LIVING):
-                sum += value
-    return sum
+    total_amount = Decimal(0)
+    for intended_use, amount in _get_rent_amount_for_year(obj, year).get_total_amounts_by_intended_uses().items():
+        if intended_use.id not in RESIDENTIAL_INTENDED_USE_IDS:
+            total_amount += amount
+
+    return total_amount
 
 
-def get_rent_amount_for_year(obj):
+def get_total_rent_amount_for_year(obj):
     year = datetime.date.today().year
-    return obj.calculate_rent_amount_for_year(year).get_total_amount()
+    return _get_rent_amount_for_year(obj, year).get_total_amount()
 
 
-def get_floor_m2_living(obj):
-    qs = obj.basis_of_rents.filter(intended_use__id__in=LIVING).values(
-        'area_unit').annotate(amount_per_area=Avg('amount_per_area'))
-    return ' / '.join(['{} {}'.format(i.get('amount_per_area'), i.get('area_unit')) for i in qs])
+def get_average_amount_per_area_residential(obj):
+    volumes = defaultdict(list)
+    for basis_of_rent in obj.basis_of_rents.all():
+        if basis_of_rent.intended_use_id not in RESIDENTIAL_INTENDED_USE_IDS:
+            continue
+
+        volumes[basis_of_rent.area_unit].append(basis_of_rent.amount_per_area)
+
+    formats.number_format(12.34, decimal_pos=2, use_l10n=True)
+
+    return ' / '.join(['{} {}'.format(
+        formats.number_format(sum(amounts_per_area) / len(amounts_per_area), decimal_pos=2, use_l10n=True),
+        area_unit
+    ) for area_unit, amounts_per_area in volumes.items()])
 
 
-def get_floor_m2_business(obj):
-    qs = obj.basis_of_rents.exclude(intended_use__id__in=LIVING).values(
-        'area_unit').annotate(amount_per_area=Avg('amount_per_area'))
-    return ' / '.join(['{} {}'.format(i.get('amount_per_area'), i.get('area_unit')) for i in qs])
+def get_average_amount_per_area_business(obj):
+    volumes = defaultdict(list)
+    for basis_of_rent in obj.basis_of_rents.all():
+        if basis_of_rent.intended_use_id in RESIDENTIAL_INTENDED_USE_IDS:
+            continue
+
+        volumes[basis_of_rent.area_unit].append(basis_of_rent.amount_per_area)
+
+    return ' / '.join(['{} {}'.format(
+        formats.number_format(sum(amounts_per_area) / len(amounts_per_area), decimal_pos=2, use_l10n=True),
+        area_unit
+    ) for area_unit, amounts_per_area in volumes.items()])
 
 
-class LeaseStatisticReport(ReportBase):
-    name = _('Lease Statistic')
-    description = _('Lease statistics')
+class LeaseStatisticReport(AsyncReportBase):
+    name = _('Lease statistics report')
+    description = _('Shows information about leases that have started or ended between the supplied dates')
     slug = 'lease_statistic'
     input_fields = {
         'start_date': forms.DateField(label=_('Start date'), required=True),
         'end_date': forms.DateField(label=_('End date'), required=True),
         'state': forms.ChoiceField(label=_('State'), required=False, choices=LeaseState.choices()),
-        'only_active_leases': forms.BooleanField(label=_('State'), required=False)
+        'only_active_leases': forms.BooleanField(label=_('Only active leases'), required=False)
 
     }
     output_fields = {
@@ -223,147 +286,173 @@ class LeaseStatisticReport(ReportBase):
         },
         # Vuokrauksen tyyppi
         'type': {
-            'label': _('Statistic report', 'Lease type'),
-            'source': get_type
+            'label': _('Lease type'),
+            'source': get_type,
+            'width': 5,
+        },
+        # Vuokrauksen tila
+        'state': {
+            'label': _('Lease state'),
+            'serializer_field': EnumField(enum=LeaseState),
+            'width': 20,
         },
         # Valmistelija
         'preparer': {
             'label': _('Preparer'),
-            'source': get_preparer
+            'source': get_preparer,
+            'width': 20,
         },
         # Kaupunginosa
         'district': {
             'label': _('District'),
-            'source': get_district
+            'source': get_district,
+            'width': 20,
         },
         # Kohteen tunnus
         'lease_area_identifier': {
-            'label': _('Statistic report', 'Lease area identifier'),
-            'source': get_lease_area_identifier
+            'label': _('Lease area identifier'),
+            'source': get_lease_area_identifier,
+            'width': 20,
         },
-
         # Osoite
         'address': {
             'label': _('Address'),
             'source': get_address,
+            'width': 20,
         },
         # Vuokranantaja
         'lessor': {
             'label': _("Lessor"),
-            'source': get_lessor
+            'source': get_lessor,
+            'width': 30,
         },
         # Rakennuttaja
         'real_estate_developer': {
             'label': _("Real estate developer"),
+            'width': 20,
         },
-
         # Vuokralaiset
         'tenants': {
-            'label': _('Model name', 'Tenants'),
+            'label': _('Tenants'),
             'source': get_tenants,
+            'width': 40,
         },
         # Start date
         'start_date': {
             'label': _("Start date"),
+            'format': 'date',
         },
         # End date
         'end_date': {
             'label': _("End date"),
+            'format': 'date',
         },
         # Kokonaispinta-ala
         'total_area': {
-            'label': _('Statistic report', 'Total area'),
+            'label': _('Total area'),
             'source': get_total_area,
         },
-        # Rakennus-oikeus-asuminen
-        'build_permission_living': {
-            'label': _('Statistic report', 'Build permission living'),
-            'source': get_build_permission_living,
+        # Rakennus-oikeus (asuminen)
+        'permitted_building_volume_residential': {
+            'label': _('Permitted building volume (Residential)'),
+            'source': get_permitted_building_volume_residential,
+            'width': 20,
         },
-        # Vuosivuokra Asuminen
-        'rent_amount_living': {
-            'label': _('Statistic report', 'Rent amount living'),
-            'source': get_rent_amount_living,
+        # Vuosivuokra (asuminen)
+        'rent_amount_residential': {
+            'label': _('Rent amount (Residential)'),
+            'source': get_rent_amount_residential,
+            'format': 'money',
+            'width': 13,
         },
-        # Rakennusoikeus Yritystila
-        'build_permission_business': {
-            'label': _('Statistic report', 'Build permission business'),
-            'source': get_build_permission_business,
+        # Rakennusoikeus (yritystila)
+        'get_permitted_building_volume_business': {
+            'label': _('Permitted building volume (Business)'),
+            'source': get_permitted_building_volume_business,
+            'width': 20,
         },
-        # Vuosivuokra Yritystila
+        # Vuosivuokra (yritystila)
         'rent_amount_business': {
-            'label': _('Statistic report', 'Rent amount business'),
+            'label': _('Rent amount (Business)'),
             'source': get_rent_amount_business,
+            'format': 'money',
+            'width': 13,
         },
-        # Kokonais rakennusoikeus
-        'build_permission_total': {
-            'label': _('Statistic report', 'Build permission total'),
-            'source': get_build_permission_total,
+        # Kokonaisrakennusoikeus
+        'get_permitted_building_volume_total': {
+            'label': _('Permitted building volume total'),
+            'source': get_permitted_building_volume_total,
+            'width': 20,
         },
         # Vuosivuokra yhteensä
         'total_rent_amount_for_year': {
-            'label': _('Statistic report', 'Rent amount for year'),
+            'label': _('Total rent amount for year'),
             'source': get_total_rent_amount_for_year,
+            'format': 'money',
+            'width': 13,
         },
         # €/k-m2 Asuminen
-        'floor_m2_living': {
-            'label': _('Statistic report', 'Floor m2 living'),
-            'source': get_floor_m2_living,
+        'average_amount_per_area_residential': {
+            'label': _('Average amount per area (Residential)'),
+            'source': get_average_amount_per_area_residential,
+            'width': 20,
         },
         # €/k-m2 Yritystila
-        'floor_m2_business': {
-            'label': _('Statistic report', 'Floor m2 business'),
-            'source': get_floor_m2_business,
-        },
-        # Kaavamerkintä
-        'plan_units': {
-            'label': _('Model name', 'Plan units'),
-            'source': get_plan_units,
+        'get_average_amount_per_area_business': {
+            'label': _('Average amount per area (Business)'),
+            'source': get_average_amount_per_area_business,
+            'width': 20,
         },
         # Hallintamuoto
         'form_of_management': {
-            'label': _('Model name', 'Form of management'),
-            'source': get_form_of_management
+            'label': _('Form of management'),
+            'source': get_form_of_management,
+            'width': 13,
         },
-        # Eristysryhmä asunnot
+        # Erityisasunnot
         'supportive_housing': {
             'label': _('Supportive housing'),
-            'source': get_supportive_housing
+            'source': get_supportive_housing,
+            'width': 13,
         },
         # Sääntelymuoto
         'form_of_regulation': {
             'label': _('Form of regulation'),
-            'source': get_form_of_regulation
+            'source': get_form_of_regulation,
+            'width': 13,
         },
-        # Vuokraus uudelleen
+        # Uudelleenvuokraus
         're_lease': {
-            'label': _('Subvention type', 'Re-lease'),
-            'source': get_re_lease
+            'label': _('Re-lease'),
+            'source': get_re_lease,
+            'format': 'boolean',
         },
-        # Osto oikeus
-        'buy_right': {
-            'label': _('Statistic report', 'Buy right'),
-            'source': get_buy_right
+        # Osto-oikeus
+        'option_to_purchase': {
+            'label': _('Option to purchase'),
+            'source': get_option_to_purchase,
+            'format': 'boolean',
         },
         # Matti-raportti
         'matti_report': {
-            'label': _('Lease area attachment type', 'Matti report'),
-            'source': get_matti_report
+            'label': _('Matti report'),
+            'source': get_matti_report,
+            'format': 'boolean',
         },
         # Irtisanomisaika
         'notice_period': {
-            'label': _('Model name', 'Notice period'),
-            'source': get_notice_period
+            'label': _('Notice period'),
+            'source': get_notice_period,
+            'width': 20,
         },
     }
-    automatic_excel_column_labels = False
 
     def get_data(self, input_data):
         qs = Lease.objects.filter(
             (
                 Q(start_date__gte=input_data['start_date']) &
                 Q(start_date__lte=input_data['end_date'])
-             ) | (
+            ) | (
                 Q(end_date__gte=input_data['start_date']) &
                 Q(end_date__lte=input_data['end_date'])
             )
@@ -379,8 +468,17 @@ class LeaseStatisticReport(ReportBase):
             'notice_period',
         ).prefetch_related(
             'rents',
+            'rents__rent_adjustments',
+            'contracts',
             'lease_areas',
             'lease_areas__addresses',
+            'lease_areas__attachments',
+            'decisions',
+            'decisions__conditions',
+            'tenants',
+            'tenants__tenantcontact_set',
+            'tenants__tenantcontact_set__contact',
+            'basis_of_rents',
         )
 
         if input_data['state']:
@@ -391,8 +489,8 @@ class LeaseStatisticReport(ReportBase):
 
         return qs
 
-    def get_response(self, request):
-        report_data = self.get_data(self.get_input_data(request))
+    def generate_report(self, user, input_data):
+        report_data = self.get_data(input_data)
         serialized_report_data = self.serialize_data(report_data)
 
-        return Response(serialized_report_data)
+        return self.data_as_excel(serialized_report_data)

--- a/leasing/report/report_base.py
+++ b/leasing/report/report_base.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 from django_q.tasks import async_task
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import ChoiceField
 from rest_framework.response import Response
 
 from leasing.report.excel import ExcelRow, FormatType
@@ -210,9 +211,13 @@ class ReportBase:
                             field_format = formats[FormatType.MONEY]
                     elif field_format_name == 'boolean':
                         if field_value:
-                            field_value = _('Yes')
+                            field_value = str(_('Yes'))
                         else:
-                            field_value = _('No')
+                            field_value = str(_('No'))
+
+                    field_serializer_field = report.get_output_field_attr(field_name, 'serializer_field')
+                    if isinstance(field_serializer_field, ChoiceField):
+                        field_value = str(field_serializer_field.choices[field_value])
 
                     worksheet.write(row_num, column, field_value, field_format)
                     column += 1

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-26 11:29+0300\n"
+"POT-Creation-Date: 2020-05-17 12:53+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mikko Keskinen <mikko.keskinen@anders.fi>\n"
 "Language: fi\n"
@@ -514,7 +514,6 @@ msgid "Other"
 msgstr "Muu"
 
 #: leasing/enums.py:121
-#: leasing/report/lease/lease_statistic_report.py:350
 msgctxt "Lease area attachment type"
 msgid "MATTI report"
 msgstr "MATTI-raportti"
@@ -750,7 +749,6 @@ msgid "Form of management"
 msgstr "Hallintamuoto"
 
 #: leasing/enums.py:337
-#: leasing/report/lease/lease_statistic_report.py:340
 msgctxt "Subvention type"
 msgid "Re-lease"
 msgstr "Uudelleenvuokraus"
@@ -1061,8 +1059,9 @@ msgstr "Tonttityyppi"
 #: leasing/report/lease/decision_conditions_report.py:39
 #: leasing/report/lease/extra_city_rent.py:33
 #: leasing/report/lease/invoicing_disabled_report.py:24
+#: leasing/report/lease/lease_statistic_report.py:271
+#: leasing/report/lease/lease_statistic_report.py:342
 #: leasing/report/lease/reservations.py:74
-#: leasing/report/lease/lease_statistic_report.py:267
 msgid "Start date"
 msgstr "Alkupvm"
 
@@ -1080,8 +1079,9 @@ msgstr "Alkupvm"
 #: leasing/report/lease/decision_conditions_report.py:40
 #: leasing/report/lease/extra_city_rent.py:34
 #: leasing/report/lease/invoicing_disabled_report.py:28
+#: leasing/report/lease/lease_statistic_report.py:272
+#: leasing/report/lease/lease_statistic_report.py:347
 #: leasing/report/lease/reservations.py:78
-#: leasing/report/lease/lease_statistic_report.py:271
 msgid "End date"
 msgstr "Loppupvm"
 
@@ -1093,6 +1093,7 @@ msgstr "Asemakaava"
 
 #: leasing/models/basis_of_rent.py:52 leasing/models/lease.py:320
 #: leasing/models/rent.py:835 leasing/models/rent.py:1061
+#: leasing/report/lease/lease_statistic_report.py:408
 msgid "Form of management"
 msgstr "Hallintamuoto"
 
@@ -1257,8 +1258,8 @@ msgstr "Y-tunnus"
 #: leasing/models/contact.py:37 leasing/models/land_area.py:20
 #: leasing/report/lease/decision_conditions_report.py:54
 #: leasing/report/lease/extra_city_rent.py:52
+#: leasing/report/lease/lease_statistic_report.py:319
 #: leasing/report/lease/reservations.py:61
-#: leasing/report/lease/lease_statistic_report.py:247
 msgid "Address"
 msgstr "Osoite"
 
@@ -1349,7 +1350,7 @@ msgid "Contract type"
 msgstr "Sopimuksen tyyppi"
 
 #: leasing/models/contract.py:31
-#: leasing/report/lease/lease_statistic_report.py:221
+#: leasing/report/lease/lease_statistic_report.py:284
 msgid "Contract number"
 msgstr "Sopimusnumero"
 
@@ -1642,6 +1643,7 @@ msgstr "Sähköpostilokit"
 #: leasing/models/infill_development_compensation.py:34
 #: leasing/models/invoice.py:172 leasing/models/lease.py:281
 #: leasing/models/lease.py:1017 leasing/report/invoice/invoices_in_period.py:56
+#: leasing/report/lease/lease_statistic_report.py:273
 msgid "State"
 msgstr "Tila"
 
@@ -2179,7 +2181,6 @@ msgid "Plan unit"
 msgstr "Kaavayksikkö"
 
 #: leasing/models/land_area.py:314
-#: leasing/report/lease/lease_statistic_report.py:320
 msgctxt "Model name"
 msgid "Plan units"
 msgstr "Kaavayksiköt"
@@ -2264,7 +2265,6 @@ msgid "Forms of financing"
 msgstr "Rahoitusmuodot"
 
 #: leasing/models/lease.py:126
-#: leasing/report/lease/lease_statistic_report.py:325
 msgctxt "Model name"
 msgid "Form of management"
 msgstr "Hallintamuoto"
@@ -2302,7 +2302,6 @@ msgid "In ISO 8601 Duration format"
 msgstr "ISO 8601 Duration-muodossa"
 
 #: leasing/models/lease.py:157
-#: leasing/report/lease/lease_statistic_report.py:355
 msgctxt "Model name"
 msgid "Notice period"
 msgstr "Irtisanomisaika"
@@ -2336,12 +2335,13 @@ msgstr "Varauksen menettelyt"
 #: leasing/report/invoice/invoices_in_period.py:49
 #: leasing/report/invoice/open_invoices_report.py:48
 #: leasing/report/lease/lease_count_report.py:20
+#: leasing/report/lease/lease_statistic_report.py:289
 #: leasing/report/lease/rent_forecast.py:27
 msgid "Lease type"
 msgstr "Laji"
 
 #: leasing/models/lease.py:191 leasing/models/lease.py:267
-#: leasing/report/lease/lease_statistic_report.py:236
+#: leasing/report/lease/lease_statistic_report.py:307
 msgid "District"
 msgstr "Kaupunginosa"
 
@@ -2380,12 +2380,12 @@ msgid "Notice note"
 msgstr "Irtisanomisilmoituksen selite"
 
 #: leasing/models/lease.py:300
-#: leasing/report/lease/lease_statistic_report.py:252
+#: leasing/report/lease/lease_statistic_report.py:325
 msgid "Lessor"
 msgstr "Vuokranantaja"
 
 #: leasing/models/lease.py:308
-#: leasing/report/lease/lease_statistic_report.py:330
+#: leasing/report/lease/lease_statistic_report.py:414
 msgid "Supportive housing"
 msgstr "Erityisasunnot"
 
@@ -2394,7 +2394,7 @@ msgid "Statistical use"
 msgstr "Tilastollinen pääkäyttötarkoitus"
 
 #: leasing/models/lease.py:324
-#: leasing/report/lease/lease_statistic_report.py:335
+#: leasing/report/lease/lease_statistic_report.py:420
 msgid "Form of regulation"
 msgstr "Sääntelymuoto"
 
@@ -2403,6 +2403,7 @@ msgid "Hitas"
 msgstr "Hitas"
 
 #: leasing/models/lease.py:331
+#: leasing/report/lease/lease_statistic_report.py:444
 msgid "Notice period"
 msgstr "Irtisanomisaika"
 
@@ -2415,7 +2416,7 @@ msgid "Invoicing enabled?"
 msgstr "Laskutus käynnissä?"
 
 #: leasing/models/lease.py:350
-#: leasing/report/lease/lease_statistic_report.py:231
+#: leasing/report/lease/lease_statistic_report.py:301
 msgid "Preparer"
 msgstr "Valmistelija"
 
@@ -2424,7 +2425,7 @@ msgid "Is subject to VAT?"
 msgstr "Onko ALV:n alainen"
 
 #: leasing/models/lease.py:357
-#: leasing/report/lease/lease_statistic_report.py:256
+#: leasing/report/lease/lease_statistic_report.py:331
 msgid "Real estate developer"
 msgstr "Rakennuttaja"
 
@@ -2952,7 +2953,6 @@ msgid "Tenant"
 msgstr "Vuokralainen"
 
 #: leasing/models/tenant.py:38
-#: leasing/report/lease/lease_statistic_report.py:262
 msgctxt "Model name"
 msgid "Tenants"
 msgstr "Vuokralaiset"
@@ -3049,7 +3049,7 @@ msgstr "Laskun numero"
 #: leasing/report/lease/decision_conditions_report.py:45
 #: leasing/report/lease/extra_city_rent.py:38
 #: leasing/report/lease/invoicing_disabled_report.py:21
-#: leasing/report/lease/lease_statistic_report.py:217
+#: leasing/report/lease/lease_statistic_report.py:279
 msgid "Lease id"
 msgstr "Vuokraus"
 
@@ -3201,6 +3201,82 @@ msgstr "Näyttää vuokrausten lukumäärän per vuokrauslaji"
 msgid "Count"
 msgstr "Lukumäärä"
 
+#: leasing/report/lease/lease_statistic_report.py:267
+msgid "Lease statistics report"
+msgstr "Vuokrausten tilastoraportti"
+
+#: leasing/report/lease/lease_statistic_report.py:268
+msgid ""
+"Shows information about leases that have started or ended between the "
+"supplied dates"
+msgstr ""
+"Näyttää tilastoraportin vuokrauksista jotka ovat alkaneet tai loppuneet "
+"alkupvm ja loppupvm välillä"
+
+#: leasing/report/lease/lease_statistic_report.py:274
+msgid "Only active leases"
+msgstr "Vain voimassa olevat vuokraukset"
+
+#: leasing/report/lease/lease_statistic_report.py:295
+msgid "Lease state"
+msgstr "Vuokrauksen tila"
+
+#: leasing/report/lease/lease_statistic_report.py:313
+msgid "Lease area identifier"
+msgstr "Kohteen tunnus"
+
+#: leasing/report/lease/lease_statistic_report.py:336
+msgid "Tenants"
+msgstr "Vuokralaiset"
+
+#: leasing/report/lease/lease_statistic_report.py:352
+msgid "Total area"
+msgstr "Kokonaispinta-ala"
+
+#: leasing/report/lease/lease_statistic_report.py:357
+msgid "Permitted building volume (Residential)"
+msgstr "Rakennus-oikeus (asuminen)"
+
+#: leasing/report/lease/lease_statistic_report.py:363
+msgid "Rent amount (Residential)"
+msgstr "Vuosivuokra (asuminen)"
+
+#: leasing/report/lease/lease_statistic_report.py:370
+msgid "Permitted building volume (Business)"
+msgstr "Rakennusoikeus (yritystila)"
+
+#: leasing/report/lease/lease_statistic_report.py:376
+msgid "Rent amount (Business)"
+msgstr "Vuosivuokra (yritystila)"
+
+#: leasing/report/lease/lease_statistic_report.py:383
+msgid "Permitted building volume total"
+msgstr "Kokonaisrakennusoikeus"
+
+#: leasing/report/lease/lease_statistic_report.py:389
+msgid "Total rent amount for year"
+msgstr "Vuosivuokra yhteensä"
+
+#: leasing/report/lease/lease_statistic_report.py:396
+msgid "Average amount per area (Residential)"
+msgstr "Keskimääräinen yksikköhinta (asuminen)"
+
+#: leasing/report/lease/lease_statistic_report.py:402
+msgid "Average amount per area (Business)"
+msgstr "Keskimääräinen yksikköhinta (yritystila)"
+
+#: leasing/report/lease/lease_statistic_report.py:426
+msgid "Re-lease"
+msgstr "Uudelleenvuokraus"
+
+#: leasing/report/lease/lease_statistic_report.py:432
+msgid "Option to purchase"
+msgstr "Osto-oikeus"
+
+#: leasing/report/lease/lease_statistic_report.py:438
+msgid "Matti report"
+msgstr "MATTI-raportti"
+
 #: leasing/report/lease/rent_forecast.py:18
 msgid "Rent forecast"
 msgstr "Vuokraennuste"
@@ -3270,39 +3346,39 @@ msgstr "Varaustunnus"
 msgid "Reservee name"
 msgstr "Varauksensaaja"
 
-#: leasing/report/report_base.py:169 leasing/report/report_base.py:212
+#: leasing/report/report_base.py:171 leasing/report/report_base.py:214
 msgid "Yes"
 msgstr "Kyllä"
 
-#: leasing/report/report_base.py:171 leasing/report/report_base.py:214
+#: leasing/report/report_base.py:173 leasing/report/report_base.py:216
 msgid "No"
 msgstr "Ei"
 
-#: leasing/report/report_base.py:239
+#: leasing/report/report_base.py:245
 msgid "Message"
 msgstr "Viesti"
 
-#: leasing/report/report_base.py:257
+#: leasing/report/report_base.py:266
 msgid "Report \"{}\" successfully generated"
 msgstr "Raportti \"{}\" luotu onnistuneesti"
 
-#: leasing/report/report_base.py:258
+#: leasing/report/report_base.py:267
 msgid "Generated report attached"
 msgstr "Luotu raportti on liitteenä."
 
-#: leasing/report/report_base.py:265
+#: leasing/report/report_base.py:274
 msgid "Failed to generate report \"{}\""
 msgstr "Raportin \"{}\" luonti epäonnistui"
 
-#: leasing/report/report_base.py:266
+#: leasing/report/report_base.py:275
 msgid "Please try again"
 msgstr "Ole hyvä ja yritä uudelleen"
 
-#: leasing/report/report_base.py:283
+#: leasing/report/report_base.py:292
 msgid "Results will be sent by email to {}"
 msgstr "Raportti toimitetaan sähköpostilla osoitteeseen {}"
 
-#: leasing/report/viewset.py:75
+#: leasing/report/viewset.py:77
 msgid "Report type not found"
 msgstr "Raporttityyppiä ei löytynyt"
 
@@ -3626,78 +3702,3 @@ msgstr "Tietoeheysvirhe"
 #: users/views.py:13
 msgid "Users permissions"
 msgstr "Käyttäjän oikeudet"
-
-#: leasing/report/lease/lease_statistic_report.py:226
-msgctxt "Statistic report"
-msgid "Lease type"
-msgstr "Vuokrauksen tyyppi"
-
-#: leasing/report/lease/lease_statistic_report.py:241
-msgctxt "Statistic report"
-msgid "Lease area identifier"
-msgstr "Kohteen tunnus"
-
-#: leasing/report/lease/lease_statistic_report.py:275
-msgctxt "Statistic report"
-msgid "Total area"
-msgstr "Kokonaispinta-ala"
-
-#: leasing/report/lease/lease_statistic_report.py:280
-msgctxt "Statistic report"
-msgid "Build permission living"
-msgstr "Rakennus-oikeus-asuminen"
-
-#: leasing/report/lease/lease_statistic_report.py:285
-msgctxt "Statistic report"
-msgid "Rent amount living"
-msgstr "Vuosivuokra Asuminen"
-
-#: leasing/report/lease/lease_statistic_report.py:290
-msgctxt "Statistic report"
-msgid "Build permission business"
-msgstr "Rakennusoikeus Yritystila"
-
-#: leasing/report/lease/lease_statistic_report.py:300
-msgctxt "Statistic report"
-msgid "Build permission total"
-msgstr "Kokonais rakennusoikeus"
-
-#: leasing/report/lease/lease_statistic_report.py:305
-msgctxt "Statistic report"
-msgid "Rent amount for year"
-msgstr "Vuosivuokra yhteensä"
-
-#: leasing/report/lease/lease_statistic_report.py:310
-msgctxt "Statistic report"
-msgid "Floor m2 living"
-msgstr "€/k-m2 Asuminen"
-
-#: leasing/report/lease/lease_statistic_report.py:315
-msgctxt "Statistic report"
-msgid "Floor m2 business"
-msgstr "€/k-m2 Yritystila"
-
-#: leasing/report/lease/lease_statistic_report.py:345
-msgctxt "Statistic report"
-msgid "Buy right"
-msgstr "Osto oikeus"
-
-#: leasing/report/lease/lease_statistic_report.py:
-msgctxt "Statistic report"
-msgid ""
-msgstr ""
-
-#: leasing/report/lease/lease_statistic_report.py:
-msgctxt "Statistic report"
-msgid ""
-msgstr ""
-
-#: leasing/report/lease/lease_statistic_report.py:
-msgctxt "Statistic report"
-msgid ""
-msgstr ""
-
-#: leasing/report/lease/lease_statistic_report.py:
-msgctxt "Statistic report"
-msgid ""
-msgstr ""


### PR DESCRIPTION
Changes:

- Make the report asynchronous (i.e. delivered later by email)
- Change some wordings and translations
- Considerably decrease the query count
- Code style tweaks
- Add "Lease state" column
- Remove unused "plan_units" column for now
- Tweak column widths and formats in the Excel output
