### PR TITLE
Fix subprocess exiting without running

### DIFF
--- a/batchrun/job_launching.py
+++ b/batchrun/job_launching.py
@@ -43,4 +43,6 @@ class JobRunLauncher(multiprocessing.Process):
         name = batchrun_execute_job_run.__name__.rsplit(".", 1)[-1]
         command = [sys.executable, self._manage_py, name, str(self.job_run.pk)]
         with daemon.DaemonContext(umask=0o022, detach_process=True):
-            subprocess.run(command)
+            subprocess.run(
+                command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )


### PR DESCRIPTION
If the python interpreter prints something on startup, it causes a
daemonized subprocess to crash because multiprocessing has closed stdin
(?, see https://pagure.io/python-daemon/issue/45).

We fix this simply by explicitly setting stdout and stderr of the
subprocess to be started to DEVNULL.