### PR TITLE
Add tests for create invoice before tenant is active

### DIFF
--- a/leasing/tests/api/test_create_invoice.py
+++ b/leasing/tests/api/test_create_invoice.py
@@ -68,6 +68,63 @@ def test_create_invoice(
 
 
 @pytest.mark.django_db
+def test_create_invoice_before_tenant_contract_is_activated(
+    django_db_setup,
+    admin_client,
+    lease_factory,
+    tenant_factory,
+    tenant_rent_share_factory,
+    contact_factory,
+    tenant_contact_factory,
+):
+    lease = lease_factory(
+        type_id=1,
+        municipality_id=1,
+        district_id=1,
+        notice_period_id=1,
+        start_date=datetime.date(year=2000, month=1, day=1),
+        is_invoicing_enabled=True,
+    )
+
+    tenant1 = tenant_factory(lease=lease, share_numerator=1, share_denominator=1)
+    tenant_rent_share_factory(
+        tenant=tenant1, intended_use_id=1, share_numerator=1, share_denominator=1
+    )
+    contact1 = contact_factory(
+        first_name="First name 1", last_name="Last name 1", type=ContactType.PERSON
+    )
+
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant1,
+        contact=contact1,
+        start_date=datetime.date.today() + datetime.timedelta(days=30),
+    )
+
+    data = {
+        "lease": lease.id,
+        "recipient": contact1.id,
+        "due_date": datetime.date.today() + datetime.timedelta(days=2),
+        "rows": [{"amount": Decimal(10), "receivable_type": 1}],
+    }
+
+    url = reverse("invoice-list")
+    response = admin_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "%s %s" % (response.status_code, response.data)
+
+    invoice = Invoice.objects.get(pk=response.data["id"])
+
+    assert invoice.invoicing_date == timezone.now().date()
+    assert invoice.outstanding_amount == Decimal(10)
+    assert invoice.state == InvoiceState.OPEN
+
+
+@pytest.mark.django_db
 def test_create_zero_sum_invoice_state_is_paid(
     django_db_setup,
     admin_client,

--- a/leasing/tests/conftest.py
+++ b/leasing/tests/conftest.py
@@ -263,7 +263,7 @@ def lease_test_data(
             type=ContactType.PERSON,
         )
     ]
-    for i in range(3):
+    for i in range(4):
         contacts.append(
             contact_factory(
                 first_name="First name " + str(i),
@@ -295,6 +295,13 @@ def lease_test_data(
             tenant=tenant2,
             contact=contacts[3],
             start_date=timezone.now().replace(year=2019).date(),
+        ),
+        tenant_contact_factory(
+            type=TenantContactType.TENANT,
+            tenant=tenant2,
+            contact=contacts[4],
+            start_date=timezone.now().date()
+            + datetime.timedelta(days=30),  # Future tenant
         ),
     ]
 


### PR DESCRIPTION
The users need to be able to create invoices for the tenants which are not yet active.