### PR TITLE
Add permissions to modify land use agreements for all groups

### DIFF
--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -834,6 +834,15 @@ DEFAULT_MODEL_PERMS = {
         6: ("view",),
         7: ("view",),
     },
+    "landuseagreement": {
+        1: ("view", "add", "change", "delete"),
+        2: ("view", "add", "change", "delete"),
+        3: ("view", "add", "change", "delete"),
+        4: ("view", "add", "change", "delete"),
+        5: ("view", "add", "change", "delete"),
+        6: ("view", "add", "change", "delete"),
+        7: ("view", "add", "change", "delete"),
+    },
     # Batchrun
     "command": {
         1: None,


### PR DESCRIPTION
Permissions probably need fine tuning once we get more information, but grant permissions to all groups for exploring in the UI.