### PR TITLE
Allow choose only contracted plan units in plot search

### DIFF
--- a/leasing/tests/api/test_plan_unit_list_with_identifiers.py
+++ b/leasing/tests/api/test_plan_unit_list_with_identifiers.py
@@ -14,6 +14,14 @@ def test_plan_unit_list_with_identifiers(
         in_contract=True,
     )
 
+    # Add not contracted plan unit
+    plan_unit_factory(
+        identifier="PU2",
+        area=1000,
+        lease_area=lease_test_data["lease_area"],
+        in_contract=False,
+    )
+
     url = reverse("planunitlistwithidentifiers-list")
 
     response = admin_client.get(url, content_type="application/json")

--- a/leasing/viewsets/land_area.py
+++ b/leasing/viewsets/land_area.py
@@ -55,6 +55,7 @@ class PlanUnitListWithIdentifiersViewSet(mixins.ListModelMixin, GenericViewSet):
         return (
             super()
             .get_queryset()
+            .filter(in_contract=True)
             .select_related("lease_area")
             .only(
                 "id",


### PR DESCRIPTION
This is required because the plan units which aren't in contract will be
refresh every night.