### PR TITLE
Switch from full object to id in plan_acceptor of land use agreements

### DIFF
--- a/leasing/serializers/land_use_agreement.py
+++ b/leasing/serializers/land_use_agreement.py
@@ -10,10 +10,7 @@ from leasing.models.land_use_agreement import (
     LandUseAgreementIdentifier,
     LandUseAgreementType,
 )
-from leasing.serializers.decision import (
-    DecisionCreateUpdateNestedSerializer,
-    DecisionMakerSerializer,
-)
+from leasing.serializers.decision import DecisionCreateUpdateNestedSerializer
 from leasing.serializers.lease import DistrictSerializer, MunicipalitySerializer
 from users.models import User
 from users.serializers import UserSerializer
@@ -104,7 +101,6 @@ class LandUseAgreementRetrieveSerializer(
     id = serializers.ReadOnlyField()
     identifier = LandUseAgreementIdentifierSerializer(read_only=True)
     preparer = UserSerializer()
-    plan_acceptor = DecisionMakerSerializer()
     addresses = LandUseAgreementAddressSerializer(
         many=True, required=False, allow_null=True
     )

--- a/leasing/tests/api/test_land_use_agreement.py
+++ b/leasing/tests/api/test_land_use_agreement.py
@@ -35,8 +35,8 @@ def test_get_land_use_agreement(
         == land_use_agreement_test_data.land_use_contract_type.value
     )
     assert (
-        response.data.get("plan_acceptor").get("name")
-        == land_use_agreement_test_data.plan_acceptor.name
+        response.data.get("plan_acceptor")
+        == land_use_agreement_test_data.plan_acceptor.id
     )
     assert (
         response.data.get("estimated_completion_year")


### PR DESCRIPTION
The choices for this field are included in the `OPTIONS` request and the create/update API requires passing only the id, so it doesn't make sense to return the entire object when `GET`ing.