### PR TITLE
Improve the plan units modification information

### DIFF
--- a/leasing/models/land_area.py
+++ b/leasing/models/land_area.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import pgettext_lazy
 from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumField
+from model_utils.tracker import FieldTracker
 from safedelete.models import SafeDeleteModel
 
 from field_permissions.registry import field_permissions
@@ -492,6 +493,8 @@ class PlanUnit(Land):
         default=PlanUnitStatus.PRESENT,
     )
 
+    tracker = FieldTracker()
+
     recursive_get_related_skip_relations = ["lease_area"]
 
     class Meta:
@@ -501,6 +504,11 @@ class PlanUnit(Land):
     def delete(self, *args, **kwargs):
         self.validate_delete()
         super(PlanUnit, self).delete(*args, **kwargs)
+
+    def save(self, **kwargs):
+        if self.id and not self.tracker.changed():
+            return
+        super(PlanUnit, self).save(**kwargs)
 
     def validate_delete(self):
         if (

--- a/leasing/tests/management/commands/test_attach_areas.py
+++ b/leasing/tests/management/commands/test_attach_areas.py
@@ -39,9 +39,7 @@ def test_lease_area_type_area_attaching_to_lease_area(
     extra_plot = plot_factory(
         identifier="P1", area=1000, type=PlotType.REAL_PROPERTY, lease_area=lease_area
     )
-    extra_plan_unit = plan_unit_factory(
-        identifier="PU2", area=1000, lease_area=lease_area
-    )
+    plan_unit_factory(identifier="PU2", area=1000, lease_area=lease_area)
 
     # Geometry data is empty
     assert lease_area.geometry is None
@@ -56,11 +54,10 @@ def test_lease_area_type_area_attaching_to_lease_area(
 
     # Extra plot and plan unit has removed as they are not in contracts
     assert (
-        "Cleared existing current Plots ((1, {'leasing.Plot': 1})) and PlanUnits ((1, {'leasing.PlotSearchTarget': 0, 'leasing.PlanUnit': 1})) not in contract"  # noqa: E501
+        "Cleared existing current Plots ((1, {'leasing.Plot': 1})) not in contract"
         in out.getvalue()
     )
     assert lease_area.plots.filter(pk=extra_plot.id).count() == 0
-    assert lease_area.plan_units.filter(pk=extra_plan_unit.id).count() == 0
 
     # Plot saved
     assert lease_area.plots.filter(in_contract=False).count() == 1
@@ -87,3 +84,47 @@ def test_lease_area_type_area_attaching_to_lease_area(
 
     # No area value in intersect area's metadata
     assert "no 'area' value in metadata" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_plan_unit_updates_modified_at(
+    lease_area_factory,
+    plan_unit_factory,
+    area_with_intersects_test_data,
+    lease_test_data,
+    monkeypatch,
+):
+    out = StringIO()
+    args = []
+    opts = {}
+
+    lease = lease_test_data["lease"]
+
+    lease_area = lease_area_factory(
+        lease=lease,
+        identifier=area_with_intersects_test_data["area"].get_land_identifier(),
+        area=1000,
+        section_area=1000,
+    )
+
+    plan_unit = plan_unit_factory(
+        area=1000, identifier="91-28-239-3", in_contract=False, lease_area=lease_area,
+    )
+
+    # The field modified_at changes on update
+    call_command("attach_areas", stdout=out, *args, **opts)
+
+    result_plan_unit = lease_area.plan_units.get(id=plan_unit.id)
+    assert result_plan_unit.modified_at > plan_unit.modified_at
+
+    # The field modified_at not changes on update if there isn't changes
+    plan_unit.refresh_from_db()
+
+    monkeypatch.setattr(
+        "leasing.models.PlanUnit.tracker.tracker_class.changed", lambda x: {}
+    )
+
+    call_command("attach_areas", stdout=out, *args, **opts)
+
+    result_plan_unit = lease_area.plan_units.get(id=plan_unit.id)
+    assert result_plan_unit.modified_at == plan_unit.modified_at

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ faker==4.0.2              # via factory-boy
 flake8-polyfill==1.0.2    # via pep8-naming
 flake8-print==3.1.4       # via -r requirements-dev.in
 flake8==3.7.9             # via -r requirements-dev.in, flake8-polyfill, flake8-print
+importlib-metadata==2.0.0  # via pluggy, pytest
 inflection==0.3.1         # via pytest-factoryboy
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.13.0           # via -r requirements-dev.in
@@ -65,6 +66,7 @@ typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.2  # via django-stubs, mypy
 wcwidth==0.1.9            # via -c requirements.txt, prompt-toolkit, pytest
 werkzeug==1.0.1           # via -r requirements-dev.in
+zipp==3.3.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ django-enumfields
 django-environ
 django-filter
 django-helusers
+django-model-utils
 django-q
 django-safedelete
 django-sanitized-dump

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,13 +32,14 @@ django-filter==2.2.0      # via -r requirements.in
 django-helusers==0.5.6    # via -r requirements.in
 django-jsonfield-compat==0.4.4  # via -r requirements.in
 django-jsonfield==1.4.0   # via django-auditlog
+django-model-utils==4.0.0  # via -r requirements.in
 django-picklefield==2.1.1  # via django-constance, django-q
 django-q==1.2.1           # via -r requirements.in
 django-rest-swagger==2.2.0  # via -r requirements.in
 django-safedelete==0.5.4  # via -r requirements.in
 django-sanitized-dump==1.2.0  # via -r requirements.in
 django-sequences==2.4     # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-anymail, django-cors-headers, django-filter, django-helusers, django-jsonfield, django-picklefield, django-q, django-safedelete, djangorestframework, drf-oidc-auth
+django==2.2.13            # via -r requirements.in, django-anymail, django-cors-headers, django-filter, django-helusers, django-jsonfield, django-model-utils, django-picklefield, django-q, django-safedelete, djangorestframework, drf-oidc-auth
 djangorestframework-gis==0.15  # via -r requirements.in
 djangorestframework==3.11.0  # via -r requirements.in, django-rest-swagger, djangorestframework-gis, drf-oidc-auth
 docutils==0.16            # via python-daemon


### PR DESCRIPTION
The plan units modified_at field cannot change every time when the save is called. It needs to look at the fields first, that are there any changes and only after that the modified_at field can be updated. This makes it possible to compare the similar plan units by the modified_at field.