### PR TITLE
Fix local testing of Laske Export

### DIFF
--- a/laske_export/tests/conftest.py
+++ b/laske_export/tests/conftest.py
@@ -8,6 +8,7 @@ from leasing.tests.conftest import *  # noqa
 
 def pytest_configure():
     laske_export_root = tempfile.mkdtemp(prefix="laske-export-")
+    settings.LANGUAGE_CODE = "en"
     settings.LASKE_EXPORT_ROOT = laske_export_root
     settings.LASKE_SERVERS = {
         "export": {"host": "localhost", "username": "test", "password": "test"}


### PR DESCRIPTION
Overwrite the default language setting to english.