### PR TITLE
Add index adjusted rent change report

### DIFF
--- a/leasing/management/commands/set_report_permissions.py
+++ b/leasing/management/commands/set_report_permissions.py
@@ -19,6 +19,7 @@ DEFAULT_REPORT_PERMS = {
     "open_invoices": [5, 6, 7],
     "decision_conditions": [2, 3, 4, 5, 6, 7],
     "extra_city_rent": [2, 3, 4, 5, 6, 7],
+    "index_adjusted_rent_change": [2, 3, 4, 5, 6, 7],
     "lease_invoicing_disabled": [5, 6, 7],
     "lease_statistic": [2, 3, 4, 5, 6, 7],
     "lease_count": [2, 3, 4, 5, 6, 7],

--- a/leasing/report/lease/index_adjusted_rents.py
+++ b/leasing/report/lease/index_adjusted_rents.py
@@ -1,0 +1,96 @@
+from decimal import Decimal
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from leasing.models import IndexAdjustedRent
+from leasing.report.report_base import ReportBase
+
+
+class IndexAdjustedRentChangeReport(ReportBase):
+    name = _("Index adjusted rent change")
+    description = _(
+        "The percentual change of index adjusted rents between specified years"
+    )
+    slug = "index_adjusted_rent_change"
+    input_fields = {
+        "year1": forms.IntegerField(label=_("Year 1"), required=True),
+        "year2": forms.IntegerField(label=_("Year 2"), required=True),
+    }
+    output_fields = {
+        "lease_id": {"label": _("Lease id")},
+        "index_type": {"label": _("Index type")},
+        "intended_use": {"label": _("Intended use")},
+        "year1_rent_start_date": {
+            "label": _("Year1 index adjusted rent start date"),
+            "format": "date",
+        },
+        "year1_rent_end_date": {
+            "label": _("Year1 index adjusted rent end date"),
+            "format": "date",
+        },
+        "year1_rent": {"label": _("Year 1 rent"), "format": "money"},
+        "year1_factor": {"label": _("Year 1 factor")},
+        "year2_rent_start_date": {
+            "label": _("Year2 index adjusted rent start date"),
+            "format": "date",
+        },
+        "year2_rent_end_date": {
+            "label": _("Year2 index adjusted rent end date"),
+            "format": "date",
+        },
+        "year2_rent": {"label": _("Year 2 rent"), "format": "money"},
+        "year2_factor": {"label": _("Year 2 factor")},
+        "pc_change": {"label": _("Percentual change")},
+    }
+
+    def get_data(self, input_data):
+        year1 = input_data["year1"]
+        year2 = input_data["year2"]
+        year1_index_adjusted_rent_qs = (
+            IndexAdjustedRent.objects.filter(start_date__year=year1)
+            .select_related(
+                "intended_use",
+                "rent",
+                "rent__lease",
+                "rent__lease__identifier",
+                "rent__lease__identifier__type",
+                "rent__lease__identifier__district",
+                "rent__lease__identifier__municipality",
+            )
+            .prefetch_related(
+                "rent__index_adjusted_rents", "rent__index_adjusted_rents__intended_use"
+            )
+        )
+        aggregated_data = []
+        for year1_iar in year1_index_adjusted_rent_qs:
+            for iar in year1_iar.rent.index_adjusted_rents.all():
+                # Iterate instead of filter() to ensure use of prefetch
+                if iar.end_date.year != year2:
+                    continue
+                if iar.intended_use != year1_iar.intended_use:
+                    continue
+
+                # Don't divide by 0
+                if iar.amount == Decimal(0) or year1_iar.amount == Decimal(0):
+                    change = None
+                else:
+                    change = round(((iar.amount / year1_iar.amount) * 100) - 100, 2)
+
+                aggregated_data.append(
+                    {
+                        "lease_id": year1_iar.rent.lease.get_identifier_string(),
+                        "index_type": str(year1_iar.rent.index_type),
+                        "intended_use": year1_iar.intended_use.name,
+                        "year1_rent_start_date": year1_iar.start_date,
+                        "year1_rent_end_date": year1_iar.end_date,
+                        "year1_rent": year1_iar.amount,
+                        "year1_factor": year1_iar.factor,
+                        "year2_rent_start_date": iar.start_date,
+                        "year2_rent_end_date": iar.end_date,
+                        "year2_rent": iar.amount,
+                        "year2_factor": iar.factor,
+                        "pc_change": change,
+                    }
+                )
+        return aggregated_data

--- a/leasing/report/viewset.py
+++ b/leasing/report/viewset.py
@@ -16,6 +16,7 @@ from leasing.report.invoice.open_invoices_report import OpenInvoicesReport
 from leasing.report.invoice.rents_paid_by_contact import RentsPaidByContactReport
 from leasing.report.lease.decision_conditions_report import DecisionConditionsReport
 from leasing.report.lease.extra_city_rent import ExtraCityRentReport
+from leasing.report.lease.index_adjusted_rents import IndexAdjustedRentChangeReport
 from leasing.report.lease.index_types import IndexTypesReport
 from leasing.report.lease.invoicing_disabled_report import LeaseInvoicingDisabledReport
 from leasing.report.lease.lease_count_report import LeaseCountReport
@@ -34,6 +35,7 @@ ENABLED_REPORTS = [
     RentsPaidByContactReport,
     LaskeInvoiceCountReport,
     LeaseCountReport,
+    IndexAdjustedRentChangeReport,
     IndexTypesReport,
     LeaseInvoicingDisabledReport,
     RentForecastReport,

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-15 11:22+0300\n"
+"POT-Creation-Date: 2020-10-15 12:25+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mikko Keskinen <mikko.keskinen@anders.fi>\n"
 "Language: fi\n"
@@ -1851,6 +1851,7 @@ msgstr "Täydennysrakentamiskorvauspäätökset"
 #: leasing/models/rent.py:984 leasing/models/rent.py:1025
 #: leasing/models/rent.py:1428 leasing/models/tenant.py:137
 #: leasing/report/lease/extra_city_rent.py:120
+#: leasing/report/lease/index_adjusted_rents.py:47
 #: leasing/report/lease/index_types.py:114
 msgid "Intended use"
 msgstr "Käyttötarkoitus"
@@ -2936,7 +2937,8 @@ msgstr "Vuokran käyttötarkoitus"
 msgid "Cycle"
 msgstr "Vuokrakausi"
 
-#: leasing/models/rent.py:116 leasing/report/lease/index_types.py:84
+#: leasing/models/rent.py:116 leasing/report/lease/index_adjusted_rents.py:46
+#: leasing/report/lease/index_types.py:84
 #: leasing/report/lease/index_types.py:115
 msgid "Index type"
 msgstr "Indeksin tunnusnumero"
@@ -3404,6 +3406,7 @@ msgstr "Palautettu"
 #: leasing/report/invoice/open_invoices_report.py:46
 #: leasing/report/lease/decision_conditions_report.py:55
 #: leasing/report/lease/extra_city_rent.py:108
+#: leasing/report/lease/index_adjusted_rents.py:45
 #: leasing/report/lease/index_types.py:91
 #: leasing/report/lease/invoicing_disabled_report.py:19
 #: leasing/report/lease/lease_statistic_report.py:342
@@ -3569,6 +3572,58 @@ msgstr "Vuokralaiset"
 #: leasing/report/lease/lease_statistic_report.py:379
 msgid "Total area"
 msgstr "Kokonaispinta-ala"
+
+#: leasing/report/lease/index_adjusted_rents.py:37
+msgid "Index adjusted rent change"
+msgstr "Indeksitarkistettujen vuokrien muutos"
+
+#: leasing/report/lease/index_adjusted_rents.py:38
+msgid "The percentual change of index adjusted rents between specified years"
+msgstr "Näyttää indeksitarkistettujen vuokrien vertailuvuosien välisen prosentuaalisen muutoksen"
+
+#: leasing/report/lease/index_adjusted_rents.py:41
+msgid "Year 1"
+msgstr "1. vertailuvuosi"
+
+#: leasing/report/lease/index_adjusted_rents.py:42
+msgid "Year 2"
+msgstr "2. vertailuvuosi"
+
+#: leasing/report/lease/index_adjusted_rents.py:48
+msgid "Year1 index adjusted rent start date"
+msgstr "1. vuoden vuokran alkupvm"
+
+#: leasing/report/lease/index_adjusted_rents.py:49
+msgid "Year1 index adjusted rent end date"
+msgstr "1. vuoden vuokran loppupvm"
+
+#: leasing/report/lease/index_adjusted_rents.py:50
+msgid "Year 1 rent"
+msgstr "1. vuoden vuokra (€)"
+
+#: leasing/report/lease/index_adjusted_rents.py:51
+msgid "Year 1 factor"
+msgstr "1. vuoden laskentakerroin"
+
+#: leasing/report/lease/index_adjusted_rents.py:52
+msgid "Year2 index adjusted rent start date"
+msgstr "2. vuoden vuokran alkupvm"
+
+#: leasing/report/lease/index_adjusted_rents.py:53
+msgid "Year2 index adjusted rent end date"
+msgstr "2. vuoden vuokran loppupvm"
+
+#: leasing/report/lease/index_adjusted_rents.py:54
+msgid "Year 2 rent"
+msgstr "2. vuoden vuokra (€)"
+
+#: leasing/report/lease/index_adjusted_rents.py:55
+msgid "Year 2 factor"
+msgstr "2. vuoden laskentakerroin"
+
+#: leasing/report/lease/index_adjusted_rents.py:56
+msgid "Percentual change"
+msgstr "Prosentuaalinen muutos"
 
 #: leasing/report/lease/index_types.py:79
 msgid "Index type leases"
@@ -3764,7 +3819,7 @@ msgstr "Ole hyvä ja yritä uudelleen"
 msgid "Results will be sent by email to {}"
 msgstr "Raportti toimitetaan sähköpostilla osoitteeseen {}"
 
-#: leasing/report/viewset.py:85
+#: leasing/report/viewset.py:87
 msgid "Report type not found"
 msgstr "Raporttityyppiä ei löytynyt"
 


### PR DESCRIPTION
Refs [#802](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/task/802)

Adds a report for viewing the percentual change between specified years in index adjusted rents.

![image](https://user-images.githubusercontent.com/5655648/96106920-700a7d00-0ee4-11eb-8358-31ffbbc2fd59.png)
