### PR TITLE
Add a group permission to delete leasehold_transfers

### DIFF
--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -676,7 +676,7 @@ DEFAULT_MODEL_PERMS = {
         1: ("view",),
         2: ("view",),
         3: ("view", "delete"),
-        4: ("view",),
+        4: ("view", "delete"),
         5: ("view",),
         6: ("view",),
         7: ("view", "delete"),


### PR DESCRIPTION
`Syöttäjä` group should be able to delete leasehold transfer objects.

Refs [#1175](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/us/1175)