### PR TITLE
Add master id to plan search targets

### DIFF
--- a/leasing/models/land_area.py
+++ b/leasing/models/land_area.py
@@ -517,6 +517,14 @@ class PlanUnit(Land):
         if skip_modified_update:
             modified_at_field.auto_now = True
 
+    def get_master(self):
+        if self.is_master:
+            return self
+        else:
+            return PlanUnit.objects.filter(
+                lease_area=self.lease_area, identifier=self.identifier, is_master=True
+            ).first()
+
     @property
     def is_master_exist(self):
         if self.is_master:

--- a/leasing/serializers/plot_search.py
+++ b/leasing/serializers/plot_search.py
@@ -33,6 +33,7 @@ class PlotSearchTargetSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
     id = serializers.ReadOnlyField()
+    master_plan_unit_id = serializers.SerializerMethodField()
     is_master_plan_unit_deleted = serializers.SerializerMethodField()
     is_master_plan_unit_newer = serializers.ReadOnlyField(
         source="plan_unit.is_master_newer"
@@ -45,10 +46,17 @@ class PlotSearchTargetSerializer(
             "id",
             "plan_unit",
             "target_type",
+            "master_plan_unit_id",
             "is_master_plan_unit_deleted",
             "is_master_plan_unit_newer",
             "message_label",
         )
+
+    def get_master_plan_unit_id(self, obj):
+        master = obj.plan_unit.get_master()
+        if master:
+            return master.id
+        return None
 
     def get_is_master_plan_unit_deleted(self, obj):
         return not obj.plan_unit.is_master_exist

--- a/leasing/tests/api/test_plot_search.py
+++ b/leasing/tests/api/test_plot_search.py
@@ -181,6 +181,7 @@ def test_plot_search_master_plan_unit_is_deleted(
     url = reverse("plotsearch-detail", kwargs={"pk": plot_search_test_data.id})
     response = admin_client.get(url, content_type="application/json")
     assert response.status_code == 200, "%s %s" % (response.status_code, response.data)
+    assert not response.data["targets"][0]["master_plan_unit_id"]
     assert response.data["targets"][0]["is_master_plan_unit_deleted"]
     assert len(response.data["targets"][0]["message_label"]) > 0
 
@@ -213,5 +214,6 @@ def test_plot_search_master_plan_unit_is_newer(
     url = reverse("plotsearch-detail", kwargs={"pk": plot_search_test_data.id})
     response = admin_client.get(url, content_type="application/json")
     assert response.status_code == 200, "%s %s" % (response.status_code, response.data)
+    assert response.data["targets"][0]["master_plan_unit_id"] > 0
     assert response.data["targets"][0]["is_master_plan_unit_newer"]
     assert len(response.data["targets"][0]["message_label"]) > 0


### PR DESCRIPTION
This makes it easier to refresh plan unit in frontend.