### PR TITLE
Add missing fields to plot search targets

### DIFF
--- a/leasing/serializers/plot_search.py
+++ b/leasing/serializers/plot_search.py
@@ -35,6 +35,21 @@ class PlotSearchTargetSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
     id = serializers.ReadOnlyField()
+
+    lease_identifier = serializers.ReadOnlyField(
+        source="plan_unit.lease_area.lease.identifier.identifier"
+    )
+    lease_hitas = serializers.ReadOnlyField(
+        source="plan_unit.lease_area.lease.hitas.name"
+    )
+    lease_address = serializers.SerializerMethodField()
+    lease_financing = serializers.ReadOnlyField(
+        source="plan_unit.lease_area.lease.financing.name"
+    )
+    lease_management = serializers.ReadOnlyField(
+        source="plan_unit.lease_area.lease.management.name"
+    )
+
     master_plan_unit_id = serializers.SerializerMethodField()
     is_master_plan_unit_deleted = serializers.SerializerMethodField()
     is_master_plan_unit_newer = serializers.ReadOnlyField(
@@ -53,7 +68,21 @@ class PlotSearchTargetSerializer(
             "is_master_plan_unit_deleted",
             "is_master_plan_unit_newer",
             "message_label",
+            "lease_identifier",
+            "lease_hitas",
+            "lease_address",
+            "lease_financing",
+            "lease_management",
         )
+
+    def get_lease_address(self, obj):
+        lease_address = (
+            obj.plan_unit.lease_area.addresses.all()
+            .order_by("-is_primary")
+            .values("address")
+            .first()
+        )
+        return lease_address
 
     def get_master_plan_unit_id(self, obj):
         master = obj.plan_unit.get_master()

--- a/leasing/tests/api/test_plot_search.py
+++ b/leasing/tests/api/test_plot_search.py
@@ -34,6 +34,10 @@ def test_plot_search_detail(
 
     response = admin_client.get(url, content_type="application/json")
     assert response.status_code == 200, "%s %s" % (response.status_code, response.data)
+    assert (
+        response.data["targets"][0]["lease_identifier"]
+        == lease_test_data["lease"].identifier.identifier
+    )
 
 
 @pytest.mark.django_db

--- a/leasing/tests/conftest.py
+++ b/leasing/tests/conftest.py
@@ -566,6 +566,7 @@ def lease_test_data(
     tenant_factory,
     tenant_contact_factory,
     lease_area_factory,
+    lease_area_address_factory,
     plot_factory,
     plan_unit_factory,
 ):
@@ -626,6 +627,11 @@ def lease_test_data(
     lease.tenants.set(tenants)
     lease_area = lease_area_factory(
         lease=lease, identifier="12345", area=1000, section_area=1000,
+    )
+
+    lease_area_address_factory(lease_area=lease_area, address="Test street 1")
+    lease_area_address_factory(
+        lease_area=lease_area, address="Primary street 1", is_primary=True
     )
 
     return {


### PR DESCRIPTION
Adding next fields to plot search targets serializer:
- lease identifier
- lease hitas
- lease address
- lease financing
- lease management

Refs [#1126](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/task/1126)