### PR TITLE
Allow null value in plan unit fields

### DIFF
--- a/leasing/serializers/land_area.py
+++ b/leasing/serializers/land_area.py
@@ -87,24 +87,28 @@ class PlanUnitCreateUpdateSerializer(
         instance_class=PlanUnitType,
         queryset=PlanUnitType.objects.filter(),
         related_serializer=PlanUnitTypeSerializer,
+        allow_null=True,
         required=False,
     )
     plan_unit_state = InstanceDictPrimaryKeyRelatedField(
         instance_class=PlanUnitState,
         queryset=PlanUnitState.objects.filter(),
         related_serializer=PlanUnitStateSerializer,
+        allow_null=True,
         required=False,
     )
     plan_unit_intended_use = InstanceDictPrimaryKeyRelatedField(
         instance_class=PlanUnitIntendedUse,
         queryset=PlanUnitIntendedUse.objects.filter(),
         related_serializer=PlanUnitIntendedUseSerializer,
+        allow_null=True,
         required=False,
     )
     plot_division_state = InstanceDictPrimaryKeyRelatedField(
         instance_class=PlotDivisionState,
         queryset=PlotDivisionState.objects.filter(),
         related_serializer=PlotDivisionStateSerializer,
+        allow_null=True,
         required=False,
     )
 


### PR DESCRIPTION
Allow null value in certain fields which aren't required and these can be set null.

Refs [#1171](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/task/1171)