### PR TITLE
Add the PlotSearch permissions also for PlotSearchSubType

### DIFF
--- a/leasing/management/commands/set_group_field_permissions.py
+++ b/leasing/management/commands/set_group_field_permissions.py
@@ -382,6 +382,15 @@ DEFAULT_FIELD_PERMS = {
         6: "view",
         7: "change",
     },
+    "plotsearchsubtype": {
+        1: None,
+        2: "change",
+        3: "view",
+        4: "change",
+        5: "change",
+        6: "view",
+        7: "change",
+    },
     "planunit": {
         1: "view",
         2: "view",


### PR DESCRIPTION
Refs [#1210](https://tree.taiga.io/project/janikuokkanen-mvj-betavaihe/issue/1210)

Even though other groups than `Selailija` should at least be able to view the `PlotSearch` objects, an error prevented doing so:
![image](https://user-images.githubusercontent.com/5655648/99375105-01965180-28cc-11eb-869c-3245ad93b267.png)

Add the `PlotSearch` permissions also to the field `PlotSearchSubType`.