### PR TITLE
Use production postgres version also in dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ python:
   - "3.7"
 
 addons:
-  postgresql: '9.5'
+  postgresql: '10'
   apt:
     packages:
-      - postgresql-9.5-postgis-2.4
+      - postgresql-10-postgis-2.4
 
 install:
   - pip install -U pip

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,8 +1,8 @@
-FROM postgres:9.5
+FROM postgres:10.15
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        postgis postgresql-9.5-postgis-2.4 postgresql-9.5-postgis-2.4-scripts
+    postgis postgresql-10-postgis-2.4 postgresql-10-postgis-2.4-scripts
 
 RUN localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
 


### PR DESCRIPTION
This requires developers to take a backup from the database and restore it again.