### PR TITLE
Fix async report crashing and add sentry support for Django Q

### DIFF
--- a/leasing/report/report_base.py
+++ b/leasing/report/report_base.py
@@ -68,8 +68,8 @@ class ReportBase:
     # If the column labels should be automatically added as the first row
     automatic_excel_column_labels = True
 
-    def __init__(self):
-        self.form = None
+    # The query form model of report
+    form = None
 
     @classmethod
     def get_output_fields_metadata(cls):
@@ -87,6 +87,10 @@ class ReportBase:
         """Initializes a form with fields from input_fields, saves the form as
         self.form instance attribute and returns it."""
         self.form = ReportFormBase(data, input_fields=self.input_fields)
+
+        # This has been set to None as the report doesn't require any form rendering
+        # and it causes pickle error in Django Q async tasks.
+        self.form.renderer = None
 
         return self.form
 

--- a/local_settings.py.template
+++ b/local_settings.py.template
@@ -1,0 +1,11 @@
+Q_CLUSTER = {
+    "name": "DjangORM",
+    "timeout": 90,
+    "retry": 60 * 60,  # 1 hour
+    "orm": "default",
+    "error_reporter": {
+        "sentry": {
+            "dsn": "https://******@sentry.io/<project>"
+        }
+    }
+}

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ django-filter
 django-helusers
 django-model-utils
 django-modeltranslation
-django-q
+django-q[sentry]
 django-safedelete
 django-sanitized-dump
 django-sequences

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,9 @@ django-picklefield==2.1.1
     # via
     #   django-constance
     #   django-q
-django-q==1.3.4
+django-q-sentry==0.1.4
+    # via django-q
+django-q[sentry]==1.3.4
     # via -r requirements.in
 django-rest-swagger==2.2.0
     # via -r requirements.in
@@ -191,8 +193,10 @@ requests==2.23.0
     #   zeep
 rsa==4.0
     # via python-jose
-sentry-sdk==0.14.3
-    # via -r requirements.in
+sentry-sdk==0.16.5
+    # via
+    #   -r requirements.in
+    #   django-q-sentry
 simplejson==3.17.0
     # via django-rest-swagger
 six==1.14.0


### PR DESCRIPTION
The async tasks of reports fails to the pickle error silenty and the requester doesn't get the report via email.

The causes was in the Django forms. The renderer isn't supported for the pickle so it crashes to this error:
```
PicklingError at /v1/report/rent_forecast/
Can't pickle <function paginator_number at 0x7f793b308400>: it's not the same object as django.contrib.admin.templatetags.admin_list.paginator_number
```
The renderer of form has been turned to None as the report feature doesn't require any rendering. This solves the pickle problem in async tasks in reports.