### PR TITLE
Add temp fix to lease statistic report

### DIFF
--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -502,6 +502,17 @@ class LeaseStatisticReport(AsyncReportBase):
                 Q(end_date__isnull=True) | Q(end_date__gte=datetime.date.today())
             )
 
+        # Skip the leases where have not set the period type of base amount in contact rents
+        # The report fails because contract rents contain items where isn't defined the period type for the base amount
+        # TODO: Review this with the specialist
+        no_period = []
+        for lease in qs:
+            for rent in lease.rents.all():
+                for cr in rent.contract_rents.all():
+                    if not cr.base_amount_period:
+                        no_period.append(lease.id)
+        qs = qs.exclude(id__in=no_period)
+
         return qs
 
     def generate_report(self, user, input_data):


### PR DESCRIPTION
Some contract rents of leases don't have set period type so the data
enrichment crashes to the monthly amount calculations. This is
a temporary fix which ignores all the leases where the period type is
missing from the contract rents.

Exception: NotImplementedError: Cannot calculate monthly amount for
PeriodType None