### PR TITLE
Remove timeout from async reports

### DIFF
--- a/leasing/report/lease/rent_forecast.py
+++ b/leasing/report/lease/rent_forecast.py
@@ -49,7 +49,6 @@ class RentForecastReport(AsyncReportBase):
         "year": {"label": _("Year")},
         "rent": {"label": _("Rent"), "format": "money", "width": 13},
     }
-    async_task_timeout = 60 * 30  # 30 minutes
 
     def get_data(self, input_data):  # NOQA C901
         start_date = datetime.date(year=input_data["start_year"], month=1, day=1)

--- a/leasing/report/report_base.py
+++ b/leasing/report/report_base.py
@@ -283,8 +283,6 @@ class ReportBase:
 
 
 class AsyncReportBase(ReportBase):
-    async_task_timeout = 60 * 30  # 30 min
-
     @classmethod
     def get_output_fields_metadata(cls):
         return {"message": {"label": _("Message")}}
@@ -322,7 +320,6 @@ class AsyncReportBase(ReportBase):
             user=user,
             input_data=input_data,
             hook=self.send_report,
-            timeout=self.async_task_timeout,
         )
 
         return Response(


### PR DESCRIPTION
The timeout will be defined in the settings.