### PR TITLE
Set base amount fields required in contract rent

### DIFF
--- a/leasing/migrations/0027_change_rent_base_fields_required.py
+++ b/leasing/migrations/0027_change_rent_base_fields_required.py
@@ -1,0 +1,46 @@
+import enumfields.fields
+from django.db import migrations, models
+
+import leasing.enums
+
+
+def forwards_func(apps, schema_editor):
+    ContractRent = apps.get_model("leasing", "ContractRent")  # noqa: N806
+
+    contract_rents_with_missing_data_qs = ContractRent.objects.exclude(
+        base_amount__isnull=False
+    ) | ContractRent.objects.exclude(base_amount_period__isnull=False)
+
+    for contract_rent in contract_rents_with_missing_data_qs:
+        if not contract_rent.base_amount:
+            contract_rent.base_amount = contract_rent.amount
+        if not contract_rent.base_amount_period:
+            contract_rent.base_amount_period = contract_rent.period
+        contract_rent.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("leasing", "0026_land_use_agreement_estate_remove_unique"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="contractrent",
+            name="base_amount",
+            field=models.DecimalField(
+                decimal_places=2, max_digits=10, verbose_name="Base amount"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="contractrent",
+            name="base_amount_period",
+            field=enumfields.fields.EnumField(
+                enum=leasing.enums.PeriodType,
+                max_length=30,
+                verbose_name="Base amount period",
+            ),
+        ),
+    ]

--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -879,20 +879,12 @@ class ContractRent(TimeStampedSafeDeleteModel):
 
     # In Finnish: Vuokranlaskennan perusteena oleva vuokra
     base_amount = models.DecimalField(
-        verbose_name=_("Base amount"),
-        null=True,
-        blank=True,
-        max_digits=10,
-        decimal_places=2,
+        verbose_name=_("Base amount"), max_digits=10, decimal_places=2,
     )
 
     # In Finnish: Yksikkö
     base_amount_period = EnumField(
-        PeriodType,
-        verbose_name=_("Base amount period"),
-        null=True,
-        blank=True,
-        max_length=30,
+        PeriodType, verbose_name=_("Base amount period"), max_length=30,
     )
 
     # In Finnish: Uusi perusvuosi vuokra

--- a/leasing/tests/models/test_calculate_invoices.py
+++ b/leasing/tests/models/test_calculate_invoices.py
@@ -361,6 +361,8 @@ def test_calculate_invoices_seasonal(
         intended_use_id=1,
         amount=80,
         period=PeriodType.PER_MONTH,
+        base_amount=80,
+        base_amount_period=PeriodType.PER_MONTH,
         start_date=date(year=2018, month=10, day=1),
         end_date=date(year=2019, month=6, day=30),
     )
@@ -369,6 +371,8 @@ def test_calculate_invoices_seasonal(
         intended_use_id=1,
         amount=80,
         period=PeriodType.PER_MONTH,
+        base_amount=80,
+        base_amount_period=PeriodType.PER_MONTH,
         start_date=date(year=2019, month=10, day=1),
         end_date=date(year=2020, month=6, day=30),
     )
@@ -392,7 +396,12 @@ def test_calculate_invoices_seasonal(
     rent2.due_dates.add(RentDueDate.objects.create(rent=rent2, month=6, day=1))
 
     contract_rent_factory(
-        rent=rent2, intended_use_id=1, amount=80, period=PeriodType.PER_MONTH
+        rent=rent2,
+        intended_use_id=1,
+        amount=80,
+        period=PeriodType.PER_MONTH,
+        base_amount=80,
+        base_amount_period=PeriodType.PER_MONTH,
     )
 
     rent3 = rent_factory(
@@ -409,7 +418,12 @@ def test_calculate_invoices_seasonal(
     rent3.due_dates.add(RentDueDate.objects.create(rent=rent3, month=7, day=1))
 
     contract_rent_factory(
-        rent=rent3, intended_use_id=1, amount=120, period=PeriodType.PER_MONTH
+        rent=rent3,
+        intended_use_id=1,
+        amount=120,
+        period=PeriodType.PER_MONTH,
+        base_amount=120,
+        base_amount_period=PeriodType.PER_MONTH,
     )
 
     rent4 = rent_factory(
@@ -428,7 +442,12 @@ def test_calculate_invoices_seasonal(
     rent4.due_dates.add(RentDueDate.objects.create(rent=rent4, month=12, day=1))
 
     contract_rent_factory(
-        rent=rent4, intended_use_id=1, amount=80, period=PeriodType.PER_MONTH
+        rent=rent4,
+        intended_use_id=1,
+        amount=80,
+        period=PeriodType.PER_MONTH,
+        base_amount=80,
+        base_amount_period=PeriodType.PER_MONTH,
     )
 
     first_day_of_year = date(year=2020, month=1, day=1)


### PR DESCRIPTION
The empty base fields has been filled with main fields. The fields have
been migrated also earlier in similar way when the old system has been
migrated to the new MVJ.

Refs:
- https://github.com/City-of-Helsinki/mvj/blob/7103b7a505eac471420e95dc9026bc9116f866da/leasing/importer/lease.py#L688-L694