### PR TITLE
Fix Finnish translation for 'Land use agreement definition'

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1751,7 +1751,7 @@ msgid "Land use agreement identifier"
 msgstr "Maankäyttösopimuksen tunnus"
 
 msgid "Land use agreement definition"
-msgstr "Maankäyttösopimus päätös"
+msgstr "Maankäyttösopimuksen määritelmä"
 
 msgid "Land use agreement status"
 msgstr "Maankäyttösopimuksen tila"


### PR DESCRIPTION
Fix the incorrect translation for "land use agreement definition".