### PR TITLE
Fill base fields with current in contract rents

### DIFF
--- a/leasing/serializers/rent.py
+++ b/leasing/serializers/rent.py
@@ -135,6 +135,15 @@ class ContractRentSerializer(
             "end_date",
         )
 
+    def to_internal_value(self, data):
+        if "amount" in data and "base_amount" not in data:
+            data["base_amount"] = data["amount"]
+
+        if "period" in data and "base_amount_period" not in data:
+            data["base_amount_period"] = data["period"]
+
+        return super().to_internal_value(data)
+
 
 class IndexAdjustedRentSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)


### PR DESCRIPTION
The base amount can be fill with the current if they are empty. There
has been several cases where the users hasn't set the base amount which
are needed in the lease statistic report.

Refs:
- https://github.com/City-of-Helsinki/mvj/pull/205