### PR TITLE
Update Django fixtures for land use agreement definitions and statuses

### DIFF
--- a/leasing/fixtures/land_use_agreement_definition.json
+++ b/leasing/fixtures/land_use_agreement_definition.json
@@ -5,5 +5,26 @@
         "fields": {
             "name": "Kiinteistö"
         }
+    },
+    {
+        "model": "leasing.LandUseAgreementDefinition",
+        "pk": 2,
+        "fields": {
+            "name": "Kaavayksikkö"
+        }
+    },
+    {
+        "model": "leasing.LandUseAgreementDefinition",
+        "pk": 3,
+        "fields": {
+            "name": "Määräala"
+        }
+    },
+    {
+        "model": "leasing.LandUseAgreementDefinition",
+        "pk": 4,
+        "fields": {
+            "name": "Muu"
+        }
     }
 ]

--- a/leasing/fixtures/land_use_agreement_status.json
+++ b/leasing/fixtures/land_use_agreement_status.json
@@ -3,7 +3,21 @@
         "model": "leasing.LandUseAgreementStatus",
         "pk": 1,
         "fields": {
-            "name": "Lorem"
+            "name": "Valmisteilla"
+        }
+    },
+    {
+        "model": "leasing.LandUseAgreementStatus",
+        "pk": 2,
+        "fields": {
+            "name": "Voimassa"
+        }
+    },
+    {
+        "model": "leasing.LandUseAgreementStatus",
+        "pk": 3,
+        "fields": {
+            "name": "Päättynyt"
         }
     }
 ]


### PR DESCRIPTION
Update the initial data for land use agreement definitions and
statuses via Django fixtures:

Land use agreement definitions	
- Kiinteistö
- Kaavayksikkö
- Määräala
- Muu

Land use agreement statuses		
- Valmisteilla
- Voimassa
- Päättynyt