### PR TITLE
Fix lease area plot list serializer

### DIFF
--- a/leasing/serializers/land_area.py
+++ b/leasing/serializers/land_area.py
@@ -297,7 +297,19 @@ class FilterLeaseAreaPlotListSerializer(serializers.ListSerializer):
 
 class LeaseAreaPlotSerializer(PlotSerializer):
     class Meta:
+        model = Plot
         list_serializer_class = FilterLeaseAreaPlotListSerializer
+        fields = (
+            "id",
+            "identifier",
+            "area",
+            "section_area",
+            "type",
+            "registration_date",
+            "repeal_date",
+            "in_contract",
+            "geometry",
+        )
 
 
 class LeaseAreaSerializer(


### PR DESCRIPTION
The model serializer was overwritten earlier and its Meta didn't contain
required parameters. This caused the 500 error in the frontend.