### PR TITLE
Fix advanced lease search filtering by geometry data

### DIFF
--- a/leasing/viewsets/lease.py
+++ b/leasing/viewsets/lease.py
@@ -408,10 +408,10 @@ class LeaseViewSet(
 
             if "has_geometry" in search_form.cleaned_data:
                 if search_form.cleaned_data.get("has_geometry") is True:
-                    queryset = queryset.filter(lease_areas__geometry__isnull=False)
+                    queryset = queryset.exclude(lease_areas__geometry__isnull=True)
 
                 if search_form.cleaned_data.get("has_geometry") is False:
-                    queryset = queryset.filter(lease_areas__geometry__isnull=True)
+                    queryset = queryset.exclude(lease_areas__geometry__isnull=False)
 
             if search_form.cleaned_data.get("property_identifier"):
                 property_identifier = search_form.cleaned_data.get(


### PR DESCRIPTION
For some reason filtering on a queryset apparently returns safe deleted objects (see below).
Replacing the filter with an exclude clause seems to solve this and returns the correct objects.

e.g. Lease `T1120-31` does have lease areas with geometry data, so it should not be included in the results when "missing geometry" filter is selected.

```
In [8]: queryset                                                                                                         
Out[8]: <SafeDeleteQueryset [<Lease: T1120-31>]>

In [9]: queryset.filter(lease_areas__geometry__isnull=True)                                                              
Out[9]: <SafeDeleteQueryset [<Lease: T1120-31>, <Lease: T1120-31>, <Lease: T1120-31>, <Lease: T1120-31>]>

In [10]: queryset.exclude(lease_areas__geometry__isnull=False)                                                            
Out[10]: <SafeDeleteQueryset []>
```

Refs #1327