### PR TITLE
Add status and estate id to land use agreement search fields

### DIFF
--- a/leasing/viewsets/land_use_agreement.py
+++ b/leasing/viewsets/land_use_agreement.py
@@ -143,10 +143,13 @@ class LandUseAgreementViewSet(
         SearchFilter,
     )
     search_fields = [
+        "^estate_ids__estate_id",
         "^identifier__identifier",
         "litigants__contacts__first_name",
         "litigants__contacts__last_name",
+        "litigants__contacts__name",
         "^plan_number",
+        "status__name",
     ]
 
     def get_serializer_class(self):


### PR DESCRIPTION
Allows searching land use agreements by the agreement status and estate ids (kiinteistötunnus).

Also add the contact `name` field to allow searching for company contacts.

Refs #1365