### PR TITLE
Set amount correctly to lua invoicerow serializers

### DIFF
--- a/leasing/serializers/land_use_agreement.py
+++ b/leasing/serializers/land_use_agreement.py
@@ -681,7 +681,6 @@ class LandUseAgreementInvoiceRowCreateUpdateSerializer(
             "plan_lawfulness_date",
             "receivable_type",
             "sign_date",
-            "amount",
         )
 
     def create(self, validated_data):
@@ -958,6 +957,7 @@ class LandUseAgreementInvoiceRowSerializer(
             "plan_lawfulness_date",
             "receivable_type",
             "sign_date",
+            "amount",
         )
 
 


### PR DESCRIPTION
Amount can retrieve but it is not needed in create or update as it will
be always calculated in the create/update methods.