### PR TITLE
requirements: Update drf-oidc-auth to 0.10.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,6 +22,15 @@ django-sequences
 djangorestframework
 djangorestframework-gis
 django-rest-swagger
+
+# Use at least 0.10.0 version of drf-oidc-auth.
+#
+# This is not a direct requirement of the project, since django-helusers
+# already requires drf-oidc-auth, but we need at least version 0.10.0,
+# because there's a bug related to "azp" parameter handling of the
+# id_token in the 0.9.0 version.
+drf-oidc-auth>=0.10.0
+
 docxtpl
 psycopg2-binary
 pysftp

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,7 +117,9 @@ docutils==0.16
 docxtpl==0.6.3
     # via -r requirements.in
 drf-oidc-auth==0.10.0
-    # via django-helusers
+    # via
+    #   -r requirements.in
+    #   django-helusers
 ecdsa==0.15
     # via python-jose
 future==0.18.2


### PR DESCRIPTION
Update the drf-oidc-auth library to version 0.10.0, because there's a
bug in 0.9.0 version that would make the production environment totally
broken for users logged in via Tunnistamo.

The version 0.10.0 is already installed to production to solve the
issue.  It's good to have the requirements.txt match to the version
installed so that it won't be downgraded again on next update.