### PR TITLE
Write tests for get_payments_from_laske

### DIFF
--- a/.github/workflows/mvj-ci.yml
+++ b/.github/workflows/mvj-ci.yml
@@ -28,6 +28,20 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+      ftp:
+        image: fauria/vsftpd
+        env:
+          PASV_ADDRESS: localhost
+          PASV_ADDR_RESOLVE: "YES"
+          PASV_MIN_PORT: 21100
+          PASV_MAX_PORT: 21200
+          FTP_USER: test
+          FTP_PASS: test
+          LOG_STDOUT: "true"
+        ports:
+          - "21:21"
+          - "21100-21200:21100-21200"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,6 +73,9 @@ jobs:
           isort . --check-only --diff
 
       - name: Run tests
+        env:
+          TEST_FTP_ACTIVE: 1
+          FTP_HOST: localhost
         run: | 
           pytest -ra -vvv --doctest-modules --cov=.
           ./run-type-checks

--- a/laske_export/tests/conftest.py
+++ b/laske_export/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -13,6 +14,62 @@ def pytest_configure():
     settings.LASKE_SERVERS = {
         "export": {"host": "localhost", "username": "test", "password": "test"}
     }
+
+
+def pytest_runtest_setup(item):
+    if item.get_closest_marker("ftp") and os.environ.get(
+        "TEST_FTP_ACTIVE", False
+    ) not in [1, "1", True, "True"]:
+        pytest.skip("test requires TEST_FTP_ACTIVE to be true")
+
+
+ftp_settings = {
+    "payments": {
+        "host": os.getenv("FTP_HOST", "ftp"),
+        "port": 21,
+        "username": "test",
+        "password": "test",
+        "directory": "/payments",
+    }
+}
+
+
+@pytest.fixture
+def setup_ftp(monkeypatch, use_ftp):
+    monkeypatch.setattr(settings, "LASKE_SERVERS", ftp_settings)
+    ftp = use_ftp
+    ftp.mkd("/payments")
+    ftp.cwd("/payments")
+    ftp.mkd("arch/")
+    yield
+    # Cleanup all the folders / files from ftp after test
+    ftp.cwd("/payments")
+    arch_files = ftp.nlst("arch/")
+    payment_files = ftp.nlst()
+    for obj in arch_files:
+        ftp.delete(obj)
+    for payment_file in payment_files:
+        try:
+            ftp.delete(payment_file)
+        except Exception:
+            ftp.rmd(payment_file)
+            continue
+    ftp.cwd("/")
+    ftp.rmd("payments/")
+    ftp.quit()
+
+
+@pytest.fixture
+def use_ftp():
+    from ftplib import FTP
+
+    ftp = FTP(
+        host=ftp_settings["payments"]["host"],
+        user=ftp_settings["payments"]["username"],
+        passwd=ftp_settings["payments"]["password"],
+        timeout=100,
+    )
+    return ftp
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/laske_export/tests/test_payments.py
+++ b/laske_export/tests/test_payments.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+
+from laske_export.management.commands import get_payments_from_laske
+
+
+@pytest.mark.django_db
+def test_unimported_files(monkeypatch):
+    test_files = [
+        "MR_OUT_ID256_8000_20190923_014512.TXT",
+        "MR_OUT_ID256_8000_20191002_014527.TXT",
+        "MR_OUT_ID256_8000_20191011_014517.TXT",
+    ]
+    laske_command = get_payments_from_laske.Command()
+    with tempfile.TemporaryDirectory() as directory:
+        monkeypatch.setattr(settings, "LASKE_EXPORT_ROOT", directory)
+        directory_path = Path(directory)
+        os.mkdir(directory_path / "payments")
+        for test_file in test_files:
+            with open(directory_path / "payments" / test_file, "w") as f:
+                f.write("")
+        files = laske_command.find_unimported_files()
+        assert len(files) == 2
+        assert not any(
+            "MR_OUT_ID256_8000_20191011_014517.TXT" in file for file in files
+        )
+
+
+@pytest.mark.django_db
+@pytest.mark.ftp
+def test_download_and_archive_payments_ftp(monkeypatch, setup_ftp, use_ftp):
+    ftp = use_ftp
+    test_files = [
+        "MR_OUT_ID256_8000_20190923_014512.TXT",
+        "MR_OUT_ID256_8000_20191002_014527.TXT",
+        "MR_OUT_ID256_8000_20191011_014517.TXT",
+        "ML_OUT_ID256_8000_20191126_085824.TXT",
+    ]
+    with tempfile.TemporaryDirectory() as directory:
+        for test_file in test_files:
+            with open(f"{directory}/{test_file}", "wb+") as f:
+                ftp.storbinary(f"STOR {test_file}", f)
+    laske_command = get_payments_from_laske.Command()
+    with tempfile.TemporaryDirectory() as directory:
+        monkeypatch.setattr(settings, "LASKE_EXPORT_ROOT", directory)
+        os.mkdir(f"{directory}/payments")
+        laske_command.download_payments_ftp()
+        archived_files = ftp.nlst("arch/")
+        assert "arch/MR_OUT_ID256_8000_20190923_014512.TXT" in archived_files
+        assert "arch/ML_OUT_ID256_8000_20191126_085824.TXT" not in archived_files
+
+
+@pytest.mark.django_db
+@pytest.mark.ftp
+def test_handle(monkeypatch, setup_ftp, use_ftp):
+    ftp = use_ftp
+    test_files = [
+        "MR_OUT_ID256_8000_20190923_014512.TXT",
+        "MR_OUT_ID256_8000_20191002_014527.TXT",
+        "MR_OUT_ID256_8000_20191011_014517.TXT",
+        "ML_OUT_ID256_8000_20191126_085824.TXT",
+    ]
+    with tempfile.TemporaryDirectory() as directory:
+        for test_file in test_files:
+            with open(f"{directory}/{test_file}", "wb+") as f:
+                ftp.storbinary(f"STOR {test_file}", f)
+    laske_command = get_payments_from_laske.Command()
+    with tempfile.TemporaryDirectory() as directory:
+        monkeypatch.setattr(settings, "LASKE_EXPORT_ROOT", directory)
+        directory_path = Path(directory)
+        os.mkdir(directory_path / "payments")
+        laske_command.handle()
+        ignored_files = ftp.nlst()
+        assert ["ML_OUT_ID256_8000_20191126_085824.TXT", "arch"] == ignored_files
+        archived_files = ftp.nlst("arch/")
+        assert [
+            "arch/MR_OUT_ID256_8000_20190923_014512.TXT",
+            "arch/MR_OUT_ID256_8000_20191002_014527.TXT",
+            "arch/MR_OUT_ID256_8000_20191011_014517.TXT",
+        ] == archived_files

--- a/leasing/fixtures/laske_payment_logs.json
+++ b/leasing/fixtures/laske_payment_logs.json
@@ -1,0 +1,44 @@
+[
+  {
+    "model": "laske_export.laskepaymentslog",
+    "pk": 1,
+    "fields": {
+      "deleted": null,
+      "created_at": "2019-10-11T12:10:32.543Z",
+      "modified_at": "2019-10-11T12:10:32.556Z",
+      "filename": "MR_OUT_ID256_8000_20191011_014517.TXT",
+      "started_at": "2019-10-11T12:10:32.541Z",
+      "ended_at": "2019-10-11T12:10:32.553Z",
+      "is_finished": true,
+      "payments": []
+    }
+  },
+  {
+    "model": "laske_export.laskepaymentslog",
+    "pk": 2,
+    "fields": {
+      "deleted": null,
+      "created_at": "2019-10-11T12:10:32.558Z",
+      "modified_at": "2019-10-11T12:10:32.566Z",
+      "filename": "MR_OUT_ID256_8000_20190923_014512.TXT",
+      "started_at": "2019-10-11T12:10:32.557Z",
+      "ended_at": "2019-10-11T12:10:32.563Z",
+      "is_finished": false,
+      "payments": []
+    }
+  },
+  {
+    "model": "laske_export.laskepaymentslog",
+    "pk": 3,
+    "fields": {
+      "deleted": null,
+      "created_at": "2019-10-11T12:10:32.568Z",
+      "modified_at": "2019-10-11T12:10:32.576Z",
+      "filename": "MR_OUT_ID256_8000_20191002_014527.TXT",
+      "started_at": "2019-10-11T12:10:32.567Z",
+      "ended_at": "2019-10-11T12:10:32.573Z",
+      "is_finished": false,
+      "payments": []
+    }
+  }
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ norecursedirs =
     leasing/importer
     leasing/management/commands
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
+markers =
+    ftp: mark a test as requiring FTP Server
 
 [isort]
 multi_line_output=3


### PR DESCRIPTION
Write tests for the get_payments_from_laske module. This will start actual ftp server as service which mimics the Laske system and goes through the whole process of handling the files.