### PR TITLE
Fix invoicing preview error

### DIFF
--- a/leasing/models/lease.py
+++ b/leasing/models/lease.py
@@ -767,9 +767,12 @@ class Lease(TimeStampedSafeDeleteModel):
 
             if leftover_ranges:
                 # TODO: Which tenantcontact to use when multiple tenantcontacts
-                if tenant_tenantcontacts[0].contact not in shares:
-                    shares[tenant_tenantcontacts[0].contact] = {tenant: []}
-                shares[tenant_tenantcontacts[0].contact][tenant].extend(leftover_ranges)
+                contact = tenant_tenantcontacts[0].contact
+                if contact not in shares:
+                    shares[contact] = {}
+                if tenant not in shares[contact]:
+                    shares[contact][tenant] = []
+                shares[contact][tenant].extend(leftover_ranges)
 
         return shares
 


### PR DESCRIPTION
When tenant is used as billing contact on another tenant and vice versa shares will have duplicate tenant keys which leads to KeyError. This will fix the issue.