### PR TITLE
Add external_id to defaults in area import

### DIFF
--- a/leasing/importer/area.py
+++ b/leasing/importer/area.py
@@ -360,6 +360,7 @@ class AreaImporter(BaseImporter):
                 other_data = {
                     "geometry": geom,
                     "metadata": metadata,
+                    "external_id": row.id,
                 }
 
                 try:


### PR DESCRIPTION
Currently, the Area import process fails into update_or_create-method as
the Area table can contain duplications and in the catch block it fails
into external_id variable as it is not included in the other_areas
dict which breaks the entire import process.

The external_id has now added to other_areas dict that it will be added
by default and the catch block works correctly when it removes
duplications.

Now it also works originally before other fixes https://github.com/City-of-Helsinki/mvj/commit/f354ce83e789e275d6308b75e16f8051820938bb#diff-1f70c6e1873821c0a0fd3f9a7b161a09f7748f47856b60f923576b35f175ab7b