### PR TITLE
Fix the convert of plan unit status

### DIFF
--- a/leasing/management/commands/attach_areas.py
+++ b/leasing/management/commands/attach_areas.py
@@ -268,9 +268,14 @@ class Command(BaseCommand):
                                 "plan_unit_type": plan_unit_type,
                                 "plan_unit_state": plan_unit_state,
                                 "plan_unit_intended_use": plan_unit_intended_use,
-                                "plan_unit_status": plan_unit_state.to_enum(),
                                 "master_timestamp": datetime.now(),
                             }
+
+                            # Set plan unit status
+                            if plan_unit_state.to_enum() is not None:
+                                rest_data[
+                                    "plan_unit_status"
+                                ] = plan_unit_state.to_enum()
 
                             # Get or create plan unit
                             (


### PR DESCRIPTION
If the plan unit status is None, it cannot be set to the database table
as it requires the value.

Added the converting that the None value is not possible and if the value is None, it uses
default value of the table.