### PR TITLE
Fix import_index tilastokeskus urls

### DIFF
--- a/leasing/management/commands/import_index.py
+++ b/leasing/management/commands/import_index.py
@@ -9,25 +9,25 @@ from leasing.models.rent import LegacyIndex
 INDEX_IMPORTS = [
     {
         "name": "Elinkustannusindeksi 1951:100 (kuukasittaiset)",
-        "url": "https://pxnet2.stat.fi/PXWeb/api/v1/fi/StatFin/hin/khi/kk/statfin_khi_pxt_11xl.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xl.px",
     },
     {
         "name": "Elinkustannusindeksi 1951:100 (vuosittaiset)",
-        "url": "https://pxnet2.stat.fi/PXWeb/api/v1/fi/StatFin/hin/khi/vv/statfin_khi_pxt_11xm.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xm.px",
     },
     {
         "name": "Elinkustannusindeksi 1938:8-1939:7 = 100 (kuukausittaiset)",
-        "url": "https://pxnet2.stat.fi/PXWeb/api/v1/fi/StatFin/hin/khi/kk/statfin_khi_pxt_11xn.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xn.px",
         "legacy": "number_1938",
     },
     {
         "name": "Elinkustannusindeksi 1938:8-1939:7 = 100 (vuosittaiset)",
-        "url": "https://pxnet2.stat.fi/PXWeb/api/v1/fi/StatFin/hin/khi/vv/statfin_khi_pxt_11xp.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xp.px",
         "legacy": "number_1938",
     },
     {
         "name": "Elinkustannusindeksi 1914:1-6 = 100 (vuosittaiset)",
-        "url": "https://pxnet2.stat.fi/PXWeb/api/v1/fi/StatFin/hin/khi/vv/statfin_khi_pxt_11xy.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xy.px",
         "legacy": "number_1914",
     },
 ]


### PR DESCRIPTION
Old pxnet2 urls were removed in November. Switch to using new statfin.stat.fi url.

ref.
https://www.stat.fi/tup/tilastotietokannat/pxnet2-alkuiset-tietokantalinkit-poistuvat-kokonaan-kaytosta.html