### PR TITLE
Slightly update dockerfiles

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -3,8 +3,14 @@ FROM python:3.8
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y gdal-bin=3.5.1 python3-gdal \
+RUN apt-get update
+
+# Force pynacl to use the system libsodium to make installation work on ARM CPUs
+# https://github.com/pyca/pynacl/issues/553
+RUN apt install --yes libsodium-dev
+RUN SODIUM_INSTALL=system pip3 install pynacl==1.3.0
+
+RUN apt-get install --no-install-recommends -y gdal-bin python3-gdal \
     && apt-get install --no-install-recommends -y gettext postgresql-client
 
 RUN mkdir /code

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,8 +1,8 @@
-FROM postgres:10.15
+FROM postgres:12.13
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-    postgis postgresql-10-postgis-2.4 postgresql-10-postgis-2.4-scripts
+    postgis postgresql-12-postgis-3 postgresql-12-postgis-3-scripts
 
 RUN localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
 

--- a/forms/tests/test_serializers.py
+++ b/forms/tests/test_serializers.py
@@ -66,7 +66,7 @@ def generate_entries(section, entries):
     entries["fields"] = dict()
     entries["sections"] = dict()
     for field in section.fields.all():
-        entries["fields"][field.identifier] = fake.name()
+        entries["fields"][field.identifier] = {"value": fake.name(), "extraValue": ""}
     for subsection in section.subsections.all():
         entries["sections"][subsection.identifier] = dict()
         generate_entries(subsection, entries["sections"][subsection.identifier])


### PR DESCRIPTION
This PR deals with two issues that I encountered after I was compelled to rebuild my backend Docker images due to a development laptop upgrade.

CC'd also to Mikko as decided in the daily.

## The database container base image is no longer supported in its current state
The docker image used for the database container used to be set to 10.15. However, it's no longer a suitable image since the 10.15 image uses Debian Stretch, whose packages were first deprecated and then removed from the official PostgreSQL repository last year:
https://www.postgresql.org/message-id/Y2kmqL%2BpCuSZiQBV%40msg.df7cb.de

There were a few possible solutions to fix this, including
- either only changing the major Linux distribution version (i.e. changing to `10.23-bullseye`)
- making a small incremental update (i.e. changing to any last-minor-version image for a newer PSQL major version)
- updating to the newest image available (i.e. changing to `15.1`)
- adding commands to the dockerfile to make the build use the archive repository instead. 
 
I opted to go with the second option to both give some breathing room (as PSQL 10 itself is for now the oldest supported version) and minimize any possible issues from a drastic version jump. If you think upgrading only to PSQL 11, or going all the way to PSQL 15, is a better option, we can do that too instead. The important point is that the current one gets replaced with _something_ that is still supported.

## Django image wasn't installable with an ARM-based device
For some reason or another, the `pynacl` Python package fails one of its test suite tests during the dependency installation step and thus refuses to install, though only when building the image on an ARM-based device like a recent MacBook Pro with an M1 chip. When I looked up if anyone else had had this issue, I came across a short and sweet workaround and implemented this in the dockerfile. I haven't tested this on an x64 device, though it doesn't seem like it should break anything.