### PR TITLE
Changed kaavatunnus to kaavanumero

### DIFF
--- a/leasing/importer/area.py
+++ b/leasing/importer/area.py
@@ -101,7 +101,7 @@ AREA_IMPORT_TYPES = {
         SELECT *, ST_AsText(ST_CollectionExtract(ST_MakeValid(ST_Transform(ST_CurveToLine(a.geom), 4326)), 3))
             AS geom_text
         FROM maka.hankerajaus_alue_kaavahanke AS a
-        WHERE kaavatunnus IS NOT NULL
+        WHERE kaavanumero IS NOT NULL
         """,
     },
     # Vuokra-alueet


### PR DESCRIPTION
Changed kaavatunnus to kaavanumero since kaavatunnus column does not exist in maka.hankerajaus_alue_kaavahanke table in lease area database.