### PR TITLE
Expose plot search stage endpoint in the public API

### DIFF
--- a/mvj/urls.py
+++ b/mvj/urls.py
@@ -234,6 +234,9 @@ pub_router.register(r"form", FormViewSet, basename="pub_form")
 pub_router.register(r"intended_use", IntendedUsePSViewSet, basename="pub_intended_use")
 pub_router.register(r"plot_search", PlotSearchViewSet, basename="pub_plot_search")
 pub_router.register(
+    r"plot_search_stage", PlotSearchStageViewSet, basename="pub_plot_search_stage"
+)
+pub_router.register(
     r"plot_search_type", PlotSearchTypeViewSet, basename="pub_plot_search_type"
 )
 pub_router.register(


### PR DESCRIPTION
The `stage` attribute from this API is needed in the public UI to find which ID represents the active search stage, which then allows filtering out any searches that aren't currently active.