### PR TITLE
Fix send_answer_email calls to use arg not kwarg

### DIFF
--- a/forms/tests/test_utils.py
+++ b/forms/tests/test_utils.py
@@ -55,15 +55,12 @@ def test_generate_and_queue_answer_emails(answer_with_email):
             "answer_id": answer.get("id"),
             "answer_type": AnswerType.AREA_SEARCH,
         }
-        generate_and_queue_answer_emails(input_data)
+        generate_and_queue_answer_emails(input_data=input_data)
 
         assert mock_async_task.called
-        (call_function,), kwargs = mock_async_task.call_args
+        call_function, email_message = mock_async_task.call_args.args
         assert call_function.__name__ == "send_answer_email"
-        data = kwargs.get("input_data")
-        answer_id = data.get("answer_id")
-        assert answer_id == answer.get("id")
-        email: EmailMessage = data.get("email_message")
+        email: EmailMessage = email_message
         assert email.from_email == settings.DEFAULT_FROM_EMAIL
         assert (
             "Kulttuuri ja vapaa-aika" in email.body

--- a/forms/utils.py
+++ b/forms/utils.py
@@ -608,9 +608,8 @@ def generate_and_queue_answer_emails(input_data: AnswerInputData) -> None:
         )
 
     for email_message in email_messages:
-        result = {"answer_id": answer_id, "email_message": email_message}
         async_task(
-            send_answer_email, input_data=result,
+            send_answer_email, email_message,
         )
 
     return
@@ -623,7 +622,7 @@ def send_answer_email(email_message: EmailMessage) -> None:
         return
 
     if not isinstance(email_message, EmailMessage):
-        raise ValueError("Task result is not an EmailMessage")
+        raise ValueError("`email_message` is not an instance of EmailMessage")
 
     try:
         email_message.send()


### PR DESCRIPTION
Fix tests that seemingly were not correctly updated

In local testing it worked - somehow, found this issue in dev.