### PR TITLE
Feat/1965 translate application emails

### DIFF
--- a/.github/workflows/mvj-ci.yml
+++ b/.github/workflows/mvj-ci.yml
@@ -40,8 +40,8 @@ jobs:
       -   name: Apt-get update
           run: sudo apt-get update
 
-      - name: Install postgis prerequisites
-        run: sudo apt-get install gdal-bin
+      - name: Install postgis & translations prerequisites
+        run: sudo apt-get install gdal-bin gettext
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/mvj-ci.yml
+++ b/.github/workflows/mvj-ci.yml
@@ -61,8 +61,9 @@ jobs:
           flake8
           isort . --check-only --diff
 
-      - name: Run tests
+      - name: Run tests, compile translations, run type checks
         run: |
+          python manage.py compilemessages
           pytest -ra -vvv --doctest-modules --cov=. --migrations
           ./run-type-checks
 

--- a/.github/workflows/mvj-ci.yml
+++ b/.github/workflows/mvj-ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -ra -vvv --doctest-modules --cov=.
+          pytest -ra -vvv --doctest-modules --cov=. --migrations
           ./run-type-checks
 
       - name: Run codecov

--- a/forms/tests/test_utils.py
+++ b/forms/tests/test_utils.py
@@ -49,7 +49,7 @@ def test_form_cloning(basic_template_form):
 def test_generate_and_queue_answer_emails(answer_with_email):
     answer = answer_with_email.get("answer")
 
-    # Case 1: Test that async_task is called, content language if Finnish
+    # Case 1: Test that async_task is called, content language is Finnish
     with patch("forms.utils.async_task") as mock_async_task:
         input_data: AnswerInputData = {
             "answer_id": answer.get("id"),
@@ -63,13 +63,12 @@ def test_generate_and_queue_answer_emails(answer_with_email):
         assert call_function.__name__ == "send_answer_email"
         email: EmailMessageInput = email_message
         assert email.get("from_email") == settings.DEFAULT_FROM_EMAIL
-        assert "Tämä on kopio Helsingin kaupungille lähetetystä aluehaun hakemuksesta." in email.get(
-            "body"
-        ) or "This is a copy of your area search application sent to the City of Helsinki." in email.get(
-            "body"
+        assert (
+            "Tämä on kopio Helsingin kaupungille lähetetystä aluehaun hakemuksesta."
+            in email.get("body")
         ), "Should contain Finnish text from the email template"
 
-    # Case 1: Test that async_task is called, content language if English
+    # Case 1: Test that async_task is called, content language is English
     with patch("forms.utils.async_task") as mock_async_task:
         input_data: AnswerInputData = {
             "answer_id": answer.get("id"),

--- a/forms/tests/test_utils.py
+++ b/forms/tests/test_utils.py
@@ -145,29 +145,27 @@ def test_generate_email_user_language(answer_with_email):
 
 #     # answer = answer_with_email.get("answer")
 #     answer_id = answer_with_email.get("answer", {}).get("id")
-#     with patch("forms.utils.async_task") as mock_async_task:
+#     with patch("forms.utils.send_answer_email") as mock_send_answer_email:
 #         input_data: AnswerInputData = {
 #             "answer_id": answer_id,
 #             "answer_type": AnswerType.AREA_SEARCH,
 #             "user_language": "fi",
 #         }
 #         generate_and_queue_answer_emails(input_data=input_data)
-#         _, kwargs = mock_async_task.call_args
-#         data = kwargs.get("input_data")
-#         email = data.get("email_message")
+#         email: EmailMessageInput = mock_send_answer_email.call_args.args[0]
 
 #     directory = (
 #         "/code/tmp"  # Change this to your desired path, this is for devcontainers only
 #     )
 #     os.makedirs(directory, exist_ok=True)
-#     for i, (filename, content, mimetype) in enumerate(email.attachments):
+#     for i, (filename, content, mimetype) in enumerate(email.get("attachments", [])):
 #         pdf_file_path = os.path.join(directory, f"{i}_{filename}")
 #         with open(pdf_file_path, "wb") as f:
 #             f.write(content)
 
-#     email_file_path = os.path.join(directory, f"{email.to[0]}")
+#     email_file_path = os.path.join(directory, f"{email.get('to')[0]}")
 #     with open(email_file_path, "wb") as f:
-#         f.write(email.body.encode("utf-8"))
+#         f.write(email.get("body").encode("utf-8"))
 
 
 def test_send_answer_email(answer_email_message: EmailMessageInput):

--- a/forms/utils.py
+++ b/forms/utils.py
@@ -596,7 +596,7 @@ def _generate_target_status_email(answer) -> EmailMessageInput:
 
     email_message: EmailMessageInput = {
         "from_email": from_email or settings.MVJ_EMAIL_FROM,
-        "to": _get_email_to_addresses(context),
+        "to": _get_email_to_addresses(answer),
         "subject": email_subject,
         "body": email_body,
         "attachments": attachments,
@@ -623,7 +623,7 @@ def _generate_area_search_email(answer) -> EmailMessageInput:
 
     email_message: EmailMessageInput = {
         "from_email": from_email or settings.MVJ_EMAIL_FROM,
-        "to": _get_email_to_addresses(context),
+        "to": _get_email_to_addresses(answer),
         "subject": email_subject,
         "body": email_body,
         "attachments": attachments,

--- a/forms/utils.py
+++ b/forms/utils.py
@@ -665,9 +665,8 @@ def generate_and_queue_answer_emails(input_data: AnswerInputData) -> None:
     with override(user_language):
         email_message_input = _generate_plotsearch_email(answer_type, answer)
 
-    async_task(
-        send_answer_email, email_message_input,
-    )
+    send_answer_email(email_message_input)
+
     return
 
 

--- a/forms/viewsets/form.py
+++ b/forms/viewsets/form.py
@@ -1,6 +1,7 @@
 from django.core.files import File
 from django.db.models import Prefetch
 from django.http import HttpResponse
+from django.utils.translation import get_language_from_request
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
@@ -134,8 +135,9 @@ class AnswerPublicViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
         return [permission() for permission in permission_classes]
 
     def create(self, request, *args, **kwargs):
+        user_language = get_language_from_request(request)
         response = super().create(request, *args, **kwargs)
-        handle_email_sending(response)
+        handle_email_sending(response, user_language)
         return response
 
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-10 14:24+0200\n"
+"POT-Creation-Date: 2023-12-13 15:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: fi\n"
@@ -401,6 +401,48 @@ msgstr "Luotu"
 
 msgid "Time modified"
 msgstr "Muokattu"
+
+msgid "Lessor"
+msgstr "Vuokranantaja"
+
+msgid "Description area"
+msgstr "Tarkempi kuvaus alueesta"
+
+msgid "District"
+msgstr "Kaupunginosa"
+
+msgid "Intended use"
+msgstr "Käyttötarkoitus"
+
+msgid "Description intended use"
+msgstr "Tarkempi kuvaus käyttötarkoituksesta"
+
+msgid "Start date"
+msgstr "Alkupvm"
+
+msgid "End date"
+msgstr "Loppupvm"
+
+msgid "Received date"
+msgstr "Vastaanotettu"
+
+msgid "Identifier"
+msgstr "Tunnus"
+
+msgid "State"
+msgstr "Tila"
+
+msgid "Preparer"
+msgstr "Valmistelija"
+
+msgid "Decline reason"
+msgstr ""
+
+msgid "Preparer note"
+msgstr ""
+
+msgid "Status notes"
+msgstr ""
 
 #, python-brace-format
 msgid "Copy of plot application(s) {target_status_identifiers}"
@@ -1054,9 +1096,6 @@ msgstr "Vireillä"
 msgid "Going to SAP"
 msgstr "Lähdössä SAP:iin"
 
-msgid "Identifier"
-msgstr "Tunnus"
-
 msgctxt "Model name"
 msgid "Area source"
 msgstr "Alueen lähde"
@@ -1109,12 +1148,6 @@ msgstr "Rakennusoikeustyypit"
 
 msgid "Plot type"
 msgstr "Tonttityyppi"
-
-msgid "Start date"
-msgstr "Alkupvm"
-
-msgid "End date"
-msgstr "Loppupvm"
 
 msgid "Detailed plan identifier"
 msgstr "Asemakaava"
@@ -1520,9 +1553,6 @@ msgctxt "Model name"
 msgid "Email logs"
 msgstr "Sähköpostilokit"
 
-msgid "State"
-msgstr "Tila"
-
 msgid "Lease contract change date"
 msgstr "Vuokrasopimuksen muutospäivämäärä"
 
@@ -1576,9 +1606,6 @@ msgstr "Täydennysrakentamiskorvauspäätös"
 msgctxt "Model name"
 msgid "Infill development compensation decisions"
 msgstr "Täydennysrakentamiskorvauspäätökset"
-
-msgid "Intended use"
-msgstr "Käyttötarkoitus"
 
 msgid "Floor m2"
 msgstr "K-m2"
@@ -1950,9 +1977,6 @@ msgstr "Maankäyttösopimuksen tyyppi"
 msgid "Municipality"
 msgstr "Kaupunki"
 
-msgid "District"
-msgstr "Kaupunginosa"
-
 msgid "Sequence number"
 msgstr "Juokseva numero"
 
@@ -1972,9 +1996,6 @@ msgstr "Maankäyttösopimuksen määritelmä"
 
 msgid "Land use agreement status"
 msgstr "Maankäyttösopimuksen tila"
-
-msgid "Preparer"
-msgstr "Valmistelija"
 
 msgid "Estimated completion year"
 msgstr "Arvioitu toteutumisvuosi"
@@ -2279,9 +2300,6 @@ msgstr "Säännelty"
 
 msgid "Notice note"
 msgstr "Irtisanomisilmoituksen selite"
-
-msgid "Lessor"
-msgstr "Vuokranantaja"
 
 msgid "Supportive housing"
 msgstr "Erityisasunnot"
@@ -3650,15 +3668,6 @@ msgstr "Kohteen tiedot ovat muuttuneet!"
 msgid "Area search information"
 msgstr "Aluehaun tiedot"
 
-msgid "Description area"
-msgstr "Tarkempi kuvaus alueesta"
-
-msgid "Description intended use"
-msgstr "Tarkempi kuvaus käyttötarkoituksesta"
-
-msgid "Received date"
-msgstr "Vastaanotettu"
-
 msgid "Information check"
 msgstr "Tietojen tarkistus"
 
@@ -3667,17 +3676,16 @@ msgstr "Aikaleima"
 
 msgid ""
 "This is a copy of your area search application sent to the City of Helsinki."
-msgstr ""
-"Tämä on kopio Helsingin kaupungille lähetetystä aluehaun hakemuksesta."
+msgstr "Tämä on kopio Helsingin kaupungille lähetetystä aluehaun hakemuksesta."
 
 msgid ""
 "You can find a detailed copy of your application as an attachment in this "
 "email."
-msgstr ""
-"Kopio hakemuksesta löytyy tämän sähköpostin liitetiedostosta."
+msgstr "Kopio hakemuksesta löytyy tämän sähköpostin liitetiedostosta."
 
-msgid "Applicants"
-msgstr "Hakijat"
+msgid ""
+"This is a copy of your plot search application sent to the City of Helsinki."
+msgstr ""
 
 msgid "yes"
 msgstr "kyllä"

--- a/plotsearch/templates/area_search/email_detail.txt
+++ b/plotsearch/templates/area_search/email_detail.txt
@@ -4,20 +4,6 @@
 {% trans "Area search information" %}
 ---
 {% trans "Identifier" %}: {{ object.identifier }}
-{% trans "Lessor" %}: {% if object.lessor_name %}{{ object.lessor_name }}{% else %} {{ object.lessor.value }}{% endif %}
-{% trans "Description area" %}: {{ object.description_area }}
-{% if object.address %}{% trans "Address" %}: {{ object.address }}{% endif %}
-{% if object.district %}{% trans "District" %}: {{ object.district }}{% endif %}
-{% if object.intended_use %}{% trans "Intended use" %}: {{ object.intended_use }}{% endif %}
-{% trans "Description intended use" %}: {{ object.description_intended_use }}
 {% trans "Start date" %}: {{ object.start_date|date:"G:i j.n.Y" }}
 {% trans "End date" %}: {{ object.end_date|date:"G:i j.n.Y" }}
 {% trans "Received date" %}: {{ object.received_date|date:"G:i j.n.Y" }}
-
-
-{% trans "Applicants" %}
----{% for applicant in applicants %}
-{% get_applicant applicant.entry_section %}{% endfor %}
-
-
-{% for section in other_sections.all|filter_only_parent %}{% include "area_search/email_other_section.txt" with section=section answer=object.answer %}{% endfor %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ per-file-ignores =
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = mvj.settings
+addopts = --nomigrations
 norecursedirs =
     .git
     venv*


### PR DESCRIPTION
Switches language to users browsers language for email and pdf generation
Refactor email generation
Remove fields from Area Search email template
Reimplement querying for email **to** addresses

In second batch of commits, I have removed the second async_task call. So now it uses one item in the queue to generate pdf and emails, and send emails. Previously it was using one to generate pdf and emails, and another async task to send emails (the reason was that previously emails were sent one by one).

I've also changed the way test are being run. This pull request changes it so that the default config does not run all migrations for tests `--nomigrations` but in CI the migrations are run `--migrations`
The reason for this change is that the setup time with migrations takes very long, and discourages creating tests because running one test takes all the setup time.