### PR TITLE
Fix/1949 target status templates

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -172,18 +172,22 @@ class LeaseAreaFactory(factory.DjangoModelFactory):
 
 
 @register
-class PlanUnitFactory(factory.DjangoModelFactory):
-    area = factory.Iterator([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
-    lease_area = factory.SubFactory(LeaseAreaFactory)
-
-    class Meta:
-        model = PlanUnit
-
-
-@register
 class PlanUnitIntendedUseFactory(factory.DjangoModelFactory):
     class Meta:
         model = PlanUnitIntendedUse
+
+
+@register
+class PlanUnitFactory(factory.DjangoModelFactory):
+    area = factory.Iterator([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
+    lease_area = factory.SubFactory(LeaseAreaFactory)
+    plan_unit_intended_use = factory.SubFactory(PlanUnitIntendedUseFactory)
+    identifier = factory.Iterator(
+        ["91-1-30-1", "91-1-30-2", "91-1-30-3", "91-1-30-4", "91-1-30-5"]
+    )
+
+    class Meta:
+        model = PlanUnit
 
 
 @register

--- a/forms/management/commands/default_plotsearch_form_sections.json
+++ b/forms/management/commands/default_plotsearch_form_sections.json
@@ -137,7 +137,7 @@
                   "choices": []
                 }
               ],
-              "applicant_type": "Company",
+              "applicant_type": "company",
               "type": "show_always"
             },
             {
@@ -283,7 +283,7 @@
                   "choices": []
                 }
               ],
-              "applicant_type": "Company",
+              "applicant_type": "company",
               "type": "show_always"
             }
           ],
@@ -481,7 +481,7 @@
               "choices": []
             }
           ],
-          "applicant_type": "Company",
+          "applicant_type": "company",
           "type": "show_always"
         },
         {
@@ -612,7 +612,7 @@
                   "choices": []
                 }
               ],
-              "applicant_type": "Person",
+              "applicant_type": "person",
               "type": "show_always"
             }
           ],
@@ -762,7 +762,7 @@
               "choices": []
             }
           ],
-          "applicant_type": "Person",
+          "applicant_type": "person",
           "type": "show_always"
         },
         {
@@ -788,7 +788,7 @@
               "choices": []
             }
           ],
-          "applicant_type": "Both",
+          "applicant_type": "both",
           "type": "show_always"
         }
       ],
@@ -819,7 +819,7 @@
           ]
         }
       ],
-      "applicant_type": "Both",
+      "applicant_type": "both",
       "type": "show_always"
     },
     {
@@ -866,7 +866,7 @@
               "choices": []
             }
           ],
-          "applicant_type": "Both",
+          "applicant_type": "both",
           "type": "show_always"
         }
       ],
@@ -1133,7 +1133,7 @@
           "choices": []
         }
       ],
-      "applicant_type": "Both",
+      "applicant_type": "both",
       "type": "show_always"
     },
     {
@@ -1204,7 +1204,7 @@
           ]
         }
       ],
-      "applicant_type": "Both",
+      "applicant_type": "both",
       "type": "show_always"
     }
   ]

--- a/forms/utils.py
+++ b/forms/utils.py
@@ -582,6 +582,7 @@ def _generate_target_status_email(answer) -> EmailMessageInput:
     target_status_identifiers = ", ".join(
         target_statuses.values_list("application_identifier", flat=True)
     )
+    context.update(target_status_identifiers=target_status_identifiers)
     from_email = settings.FROM_EMAIL_PLOT_SEARCH
     email_subject = _(f"Copy of plot application(s) {target_status_identifiers}")
     email_body = render_to_string("target_status/email_detail.txt", context)

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-14 16:37+0200\n"
+"POT-Creation-Date: 2023-12-20 16:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: fi\n"
@@ -3686,9 +3686,34 @@ msgid ""
 "email."
 msgstr "Kopio hakemuksesta löytyy tämän sähköpostin liitetiedostosta."
 
+msgid "Plot search information"
+msgstr "Tonttihaun tiedot"
+
+msgid "The deadline for applications"
+msgstr "Haku päättyy"
+
+msgid "Plot"
+msgstr "Tontti"
+
+msgid "Detailed plan state"
+msgstr "Asemakaavan käsittelyvaihe"
+
+msgid "Permitted build floor area (floor-m²)"
+msgstr "Rakennusoikeus (k-m²)"
+
+msgid "Area (m²)"
+msgstr "Pinta-ala (m²)"
+
 msgid ""
-"This is a copy of your plot search application sent to the City of Helsinki."
+"This is a confirmation that the following plot application sent to the City "
+"of Helsinki were received."
 msgstr ""
+"Helsingin kaupungille lähetetyt tonttihakemukset on vahvistetusti "
+"vastaanotettu seuraavilla tunnuksilla."
+
+msgctxt "list of identifiers in email"
+msgid "Application identifiers"
+msgstr "Hakemustunnukset"
 
 msgid "yes"
 msgstr "kyllä"
@@ -3710,6 +3735,24 @@ msgstr ""
 "Hei {receiver}! Tässä linkki suoravaraustonttihakuun: {url} \n"
 "\n"
 "{covering_note}"
+
+msgid "Permitted build residential floor area (floor-m²)"
+msgstr "Asuinrakennusoikeus (k-m²)"
+
+msgid "Permitted build commercial floor area (floor-m²)"
+msgstr "Liikerakennusoikeus (k-m²)"
+
+msgid "First suitable construction year"
+msgstr "Rakennuskelpoinen"
+
+msgid "HITAS"
+msgstr "HITAS"
+
+msgid "Financing method"
+msgstr "Rahoitusmuoto"
+
+msgid "Management method"
+msgstr "Hallintamuoto"
 
 msgid "Token exists"
 msgstr "Token olemassa"

--- a/plotsearch/templates/mixins/section.html
+++ b/plotsearch/templates/mixins/section.html
@@ -21,7 +21,7 @@
                         <th>
                             {{ field }}
                         </th>
-                        {% for entry in field.entry_set.all|filter_answer:answer|filter_applicant:applicant_identifier %}
+                        {% for entry in field.entry_set.all|filter_answer:answer|filter_applicant:applicant_identifier|filter_plot_search_target:plot_search_target %}
                             <td>
                                 {% if field.type.identifier == "checkbox" or field.type.identifier == "radiobutton" or field.type.identifier == "radiobuttoninline" %}
                                     {% fetch_choice_value entry.value entry.field.id %}

--- a/plotsearch/templates/mixins/section_target_status.html
+++ b/plotsearch/templates/mixins/section_target_status.html
@@ -21,7 +21,7 @@
                         <th>
                             {{ field }}
                         </th>
-                        {% for entry in field.entry_set.all|filter_answer:answer|filter_applicant:applicant_identifier %}
+                        {% for entry in field.entry_set.all|filter_answer:answer|filter_applicant:applicant_identifier|filter_plot_search_target:plot_search_target %}
                             <td>
                                 {% if field.type.identifier == "checkbox" or field.type.identifier == "radiobutton" or field.type.identifier == "radiobuttoninline" %}
                                     {% fetch_choice_value entry.value entry.field.id %}

--- a/plotsearch/templates/target_status/detail.html
+++ b/plotsearch/templates/target_status/detail.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 {% load form_visible %}
 {% load entry_filter %}
 
@@ -17,17 +18,29 @@
         <div>
             <h1>{{ object.application_identifier }}</h1>
         </div>
+        <div>
+            <h2>{% trans "Plot search information" %}</h2>
+            <h3>{{ plotsearch.name }}</h3>
+            <table>
+                {% for field in plotsearch_info %}
+                <tr>
+                    <th>{{ field.label|default:"" }}</th>
+                    <td>{{ field.value|default:"" }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
         <div class="divider">&nbsp;</div>
         <!--APPLICANT SECTIONS-->
         {% for applicant in applicants %}
             {% if applicant.section.applicant_type.value == applicant.applicant_type.value or applicant.section.applicant_type.value == "both" or applicant.applicant_type.value == "both" %}
-                {% include "mixins/section.html" with section=applicant.section answer=object.answer applicant_identifier=applicant.identifier applicant_type=applicant.applicant_type %}
+                {% include "mixins/section.html" with section=applicant.section answer=object.answer applicant_identifier=applicant.identifier applicant_type=applicant.applicant_type plot_search_target=None %}
             {% endif %}
         {% endfor %}
         <!--OTHER SECTIONS-->
 
         {% for section in other_sections.all|filter_only_parent %}
-            {% include "mixins/section.html" with section=section answer=object.answer applicant_identifier=None applicant_type="both" %}
+            {% include "mixins/section.html" with section=section answer=object.answer applicant_identifier=None applicant_type="both" plot_search_target=object.plot_search_target %}
         {% endfor %}
     </div>
 </body>

--- a/plotsearch/templates/target_status/detail.html
+++ b/plotsearch/templates/target_status/detail.html
@@ -34,13 +34,13 @@
         <!--APPLICANT SECTIONS-->
         {% for applicant in applicants %}
             {% if applicant.section.applicant_type.value == applicant.applicant_type.value or applicant.section.applicant_type.value == "both" or applicant.applicant_type.value == "both" %}
-                {% include "mixins/section.html" with section=applicant.section answer=object.answer applicant_identifier=applicant.identifier applicant_type=applicant.applicant_type plot_search_target=None %}
+                {% include "mixins/section_target_status.html" with section=applicant.section answer=object.answer applicant_identifier=applicant.identifier applicant_type=applicant.applicant_type plot_search_target=None %}
             {% endif %}
         {% endfor %}
         <!--OTHER SECTIONS-->
 
         {% for section in other_sections.all|filter_only_parent %}
-            {% include "mixins/section.html" with section=section answer=object.answer applicant_identifier=None applicant_type="both" plot_search_target=object.plot_search_target %}
+            {% include "mixins/section_target_status.html" with section=section answer=object.answer applicant_identifier=None applicant_type="both" plot_search_target=object.plot_search_target %}
         {% endfor %}
     </div>
 </body>

--- a/plotsearch/templates/target_status/email_detail.txt
+++ b/plotsearch/templates/target_status/email_detail.txt
@@ -1,2 +1,4 @@
-{% load i18n %}{% trans "This is a copy of your plot search application sent to the City of Helsinki." %}
+{% load i18n %}{% trans "This is a confirmation that the following plot application sent to the City of Helsinki were received." %}
+{% trans "Application identifiers" context "list of identifiers in email" %}: {{ target_status_identifiers|default:"" }}
+
 {% trans "You can find a detailed copy of your application as an attachment in this email." %}

--- a/plotsearch/templatetags/entry_filter.py
+++ b/plotsearch/templatetags/entry_filter.py
@@ -50,3 +50,21 @@ def filter_applicant(qs, applicant_identifier):
             entries.append(entry)
 
     return entries
+
+
+@register.filter
+def filter_plot_search_target(qs, plot_search_target):
+    """Exclude entries in section 'haettava-kohde' where `plot_search_target` does not match metadata."""
+    if plot_search_target is None:
+        return qs
+
+    entries = []
+    for entry in qs:
+        if not (
+            "haettava-kohde" in entry.entry_section.identifier
+            and entry.entry_section.metadata.get("identifier") != plot_search_target.id
+        ):
+            # Skip entries that are not the target, otherwise multiple targets are shown
+            entries.append(entry)
+
+    return entries

--- a/plotsearch/tests/views/test_plot_search_views.py
+++ b/plotsearch/tests/views/test_plot_search_views.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+
+import pytest
+from django.test import override_settings
+from rest_framework.serializers import ValidationError
+
+from leasing.models import CustomDetailedPlan, PlanUnit
+from plotsearch.views.plot_search import TargetStatusGeneratePDF
+
+
+def test_get_nested_attr():
+    get_nested_attr = TargetStatusGeneratePDF.get_nested_attr
+
+    @dataclass
+    class D:
+        foo = 1
+
+    @dataclass
+    class C:
+        d = D()
+
+    @dataclass
+    class B:
+        c = C()
+
+    @dataclass
+    class A:
+        b = B()
+
+    @dataclass
+    class Empty:
+        pass
+
+    a = A()
+    assert get_nested_attr(a, "b.c.d.foo") == 1
+    assert isinstance(get_nested_attr(a, "b.c"), C)
+    assert isinstance(get_nested_attr(a, "b"), B)
+    assert get_nested_attr(a, "b.c.d.foo.bar") is None
+    assert get_nested_attr(a, "b.c.d.foo.bar.baz", default="lucky") == "lucky"
+    empty = Empty()
+    assert get_nested_attr(empty, "does_not_exist") is None
+    assert get_nested_attr(a, "") is None
+
+
+@pytest.mark.django_db
+def test_target_status_pdf_get_plan(
+    target_status_factory, custom_detailed_plan_factory
+):
+    target_status = target_status_factory()
+    view = TargetStatusGeneratePDF()
+    plan = view._get_plan(target_status)
+    assert plan == target_status.plot_search_target.plan_unit
+    assert isinstance(plan, PlanUnit)
+
+    custom_detailed_plan = custom_detailed_plan_factory()
+    target_status = target_status_factory(
+        plot_search_target__custom_detailed_plan=custom_detailed_plan,
+        plot_search_target__plan_unit=None,
+    )
+    plan = view._get_plan(target_status)
+    assert plan == target_status.plot_search_target.custom_detailed_plan
+    assert isinstance(plan, CustomDetailedPlan)
+
+    custom_detailed_plan = custom_detailed_plan_factory()
+    with pytest.raises(ValidationError):
+        target_status = target_status_factory(
+            plot_search_target__custom_detailed_plan=custom_detailed_plan,
+            # plot_search_target__plan_unit gets generated in the factory
+        )
+
+    with pytest.raises(ValidationError):
+        target_status = target_status_factory(
+            plot_search_target__custom_detailed_plan=None,
+            plot_search_target__plan_unit=None,
+        )
+
+
+@pytest.mark.django_db
+def test_target_status_pdf_get_plan_intended_use(
+    target_status_factory, custom_detailed_plan_factory
+):
+    view = TargetStatusGeneratePDF()
+    target_status = target_status_factory()
+    assert (
+        view._get_plan_intended_use(target_status)
+        == target_status.plot_search_target.plan_unit.plan_unit_intended_use
+    )
+
+    custom_detailed_plan = custom_detailed_plan_factory()
+    target_status = target_status_factory(
+        plot_search_target__custom_detailed_plan=custom_detailed_plan,
+        plot_search_target__plan_unit=None,
+    )
+    assert (
+        view._get_plan_intended_use(target_status)
+        == target_status.plot_search_target.custom_detailed_plan.intended_use
+    )
+
+
+@pytest.mark.django_db
+@override_settings(LANGUAGE_CODE="en")
+def test_target_status_pdf_get_plot_search_information(target_status_factory):
+    target_status = target_status_factory(
+        plot_search_target__plan_unit__area=21345,
+        plot_search_target__plot_search__end_at=None,
+    )
+    view = TargetStatusGeneratePDF()
+    plot_search_information = view._get_plot_search_information(target_status)
+    labels = {}
+    for x in plot_search_information:
+        labels[x["label"]] = x["value"]
+    assert labels["Plot"].startswith("91-1-30-")
+    assert labels["Intended use"] == ""
+    assert labels["Area (m²)"] == 21345
+    assert (
+        "The deadline for applications" not in labels.keys()
+    ), "This key should not be here since it was set None"

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -24,6 +24,7 @@ from rest_framework_gis.filters import InBBoxFilter
 from field_permissions.viewsets import FieldPermissionsViewsetMixin
 from forms.models import Answer
 from forms.serializers.form import AnswerOpeningRecordSerializer
+from leasing.models import CustomDetailedPlan
 from leasing.permissions import (
     MvjDjangoModelPermissions,
     MvjDjangoModelPermissionsOrAnonReadOnly,
@@ -390,7 +391,7 @@ class TargetStatusGeneratePDF(PdfMixin, FilterView):
 
     def _get_plot_search_information(self, object):
         """Creates plot search information context for PDF template.
-        Generates a list of objects, excluding those without a value."""
+        Generates a list of dictionarys, excluding those without a value."""
         plan = self._get_plan(object)
         plan_intended_use = self._get_plan_intended_use(object)
 
@@ -403,9 +404,12 @@ class TargetStatusGeneratePDF(PdfMixin, FilterView):
             application_deadline = None
 
         address = getattr(plan.lease_area.addresses.first(), "address", None)
-        detailed_plan_identifier = getattr(
-            plan, "detailed_plan_identifier", None
-        ) or getattr(plan, "identifier", None)
+        detailed_plan_identifier = (
+            getattr(plan, "detailed_plan_identifier", None)
+            or getattr(plan, "identifier", None)
+            if isinstance(plan, CustomDetailedPlan)
+            else None
+        )
         detailed_plan_state = self.get_nested_attr(
             plan, "state.name"
         ) or self.get_nested_attr(plan, "plan_unit_state.name")


### PR DESCRIPTION
`plotsearch/templates/mixins/section_target_status.html` is just a copy of `plotsearch/templates/mixins/section.html` since it was used by area search also, and needed changes specifically for plot search. I did copy it in order to not increase complexity, the recursive rendering and passing arguments to the template is already a bit complex.


applicant_type commit is not related to this work, rather something I happened to discover was changed but had not been committed by _someone_, added it here not to forget it :see_no_evil: 