### PR TITLE
Add admin search field for lease identifier

### DIFF
--- a/leasing/admin.py
+++ b/leasing/admin.py
@@ -226,6 +226,8 @@ class LeaseIdentifierAdmin(FieldPermissionsModelAdmin):
 class LeaseAdmin(FieldPermissionsAdminMixin, admin.ModelAdmin):
     inlines = [RelatedLeaseInline, LeaseBasisOfRentInline]
     raw_id_fields = ("identifier",)
+    search_fields = ("identifier_id__identifier",)
+    search_help_text = _("Search by identifier")  # Will be added in django 4.0
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)


### PR DESCRIPTION
Adds a search field in django admin for Lease/vuokraus
The attribute `search_help_text` is introduced in django 4.0, and will become available after upgrade.
Looks like translation module does not pick it up currently as it doesn't recognize it, so it will have to be translated later (if needed)