### PR TITLE
Area search stepper changes

### DIFF
--- a/mvj/urls.py
+++ b/mvj/urls.py
@@ -112,8 +112,8 @@ from leasing.viewsets.vat import VatViewSet
 from plotsearch.views.plot_search import (
     AreaSearchAttachmentViewset,
     AreaSearchGeneratePDF,
-    AreaSearchViewSet,
     AreaSearchPublicViewSet,
+    AreaSearchViewSet,
     DirectReservationLinkViewSet,
     DirectReservationToFavourite,
     FAQViewSet,

--- a/mvj/urls.py
+++ b/mvj/urls.py
@@ -113,6 +113,7 @@ from plotsearch.views.plot_search import (
     AreaSearchAttachmentViewset,
     AreaSearchGeneratePDF,
     AreaSearchViewSet,
+    AreaSearchPublicViewSet,
     DirectReservationLinkViewSet,
     DirectReservationToFavourite,
     FAQViewSet,
@@ -237,7 +238,7 @@ pub_router = routers.DefaultRouter()
 
 pub_router.register(r"answer", AnswerPublicViewSet, basename="pub_answer")
 pub_router.register(r"attachment", AttachmentViewSet, basename="pub_attachment")
-pub_router.register(r"area_search", AreaSearchViewSet, basename="pub_area_search")
+pub_router.register(r"area_search", AreaSearchPublicViewSet, basename="pub_area_search")
 pub_router.register(
     r"area_search_attachment",
     AreaSearchAttachmentViewset,

--- a/plotsearch/permissions.py
+++ b/plotsearch/permissions.py
@@ -7,7 +7,7 @@ class AreaSearchPublicPermissions(PerMethodPermission):
     def has_object_permission(self, request, view, obj):
         if obj.answer is not None:
             return False
-        if obj.user != request.user:
+        if obj.user and obj.user != request.user:
             return False
         return super().has_object_permission(request, view, obj)
 

--- a/plotsearch/permissions.py
+++ b/plotsearch/permissions.py
@@ -3,6 +3,15 @@ from plotsearch.models import PlotSearch
 from users.models import User
 
 
+class AreaSearchPublicPermissions(PerMethodPermission):
+    def has_object_permission(self, request, view, obj):
+        if obj.answer is not None:
+            return False
+        if obj.user == request.user:
+            return True
+        return super().has_object_permission(request, view, obj)
+
+
 class AreaSearchAttachmentPermissions(PerMethodPermission):
     def has_object_permission(self, request, view, obj):
         if obj.area_search.user == request.user:

--- a/plotsearch/permissions.py
+++ b/plotsearch/permissions.py
@@ -7,8 +7,8 @@ class AreaSearchPublicPermissions(PerMethodPermission):
     def has_object_permission(self, request, view, obj):
         if obj.answer is not None:
             return False
-        if obj.user == request.user:
-            return True
+        if obj.user != request.user:
+            return False
         return super().has_object_permission(request, view, obj)
 
 

--- a/plotsearch/serializers/plot_search.py
+++ b/plotsearch/serializers/plot_search.py
@@ -970,7 +970,7 @@ class AreaSearchSerializer(EnumSupportSerializerMixin, serializers.ModelSerializ
             area_search_status = as_serializer.update(
                 area_search_status_qs.get(), area_search_status
             )
-        else:
+        elif area_search_status:
             area_search_status = as_serializer.create(area_search_status)
 
         instance.area_search_status = area_search_status

--- a/plotsearch/serializers/plot_search.py
+++ b/plotsearch/serializers/plot_search.py
@@ -940,6 +940,9 @@ class AreaSearchSerializer(EnumSupportSerializerMixin, serializers.ModelSerializ
         area_search.lessor = map_intended_use_to_lessor(
             validated_data.pop("intended_use", None)
         )
+        request = self.context.get("request", None)
+        if request and hasattr(request, "user"):
+            area_search.user = request.user
         area_search.save()
         for attachment in attachments:
             attachment.area_search = area_search

--- a/plotsearch/tests/api/test_plot_search.py
+++ b/plotsearch/tests/api/test_plot_search.py
@@ -649,7 +649,7 @@ def test_post_area_search_detail_empty_payload(
     django_db_setup, admin_client, area_search_test_data,
 ):
     url = reverse("areasearch-detail", kwargs={"pk": area_search_test_data.id})
-    data = {"area_search_status": {}}
+    data = {}
 
     response = admin_client.patch(url, data=data, content_type="application/json")
     assert response.status_code == 200, "%s %s" % (response.status_code, response.data)

--- a/plotsearch/tests/test_permissions.py
+++ b/plotsearch/tests/test_permissions.py
@@ -22,11 +22,15 @@ def test_area_search_public_permissions__user_check():
     request = Request()
     request.user = user
     area_search = AreaSearch()
+    permission = AreaSearchPublicPermissions()
+    has_permission = permission.has_object_permission(request, None, area_search)
+    assert has_permission is True, "AreaSearch without user should be updated"
+
     area_search.user = user
     permission = AreaSearchPublicPermissions()
     has_permission = permission.has_object_permission(request, None, area_search)
-    assert has_permission is True
+    assert has_permission is True, "AreaSearch with same user should be updated"
 
     area_search.user = UserFactory()
     has_permission = permission.has_object_permission(request, None, area_search)
-    assert has_permission is False
+    assert has_permission is False, "AreaSearch with different object should fail"

--- a/plotsearch/tests/test_permissions.py
+++ b/plotsearch/tests/test_permissions.py
@@ -1,5 +1,6 @@
 import pytest
 from requests import Request
+
 from conftest import UserFactory
 from forms.models import Answer
 from plotsearch.models.plot_search import AreaSearch

--- a/plotsearch/tests/test_permissions.py
+++ b/plotsearch/tests/test_permissions.py
@@ -1,0 +1,31 @@
+import pytest
+from requests import Request
+from conftest import UserFactory
+from forms.models import Answer
+from plotsearch.models.plot_search import AreaSearch
+from plotsearch.permissions import AreaSearchPublicPermissions
+
+
+@pytest.mark.django_db
+def test_area_search_public_permissions__answered_is_not_allowed():
+    area_search = AreaSearch()
+    area_search.answer = Answer()
+    permission = AreaSearchPublicPermissions()
+    has_permission = permission.has_object_permission(None, None, area_search)
+    assert has_permission is False
+
+
+@pytest.mark.django_db
+def test_area_search_public_permissions__user_check():
+    user = UserFactory()
+    request = Request()
+    request.user = user
+    area_search = AreaSearch()
+    area_search.user = user
+    permission = AreaSearchPublicPermissions()
+    has_permission = permission.has_object_permission(request, None, area_search)
+    assert has_permission is True
+
+    area_search.user = UserFactory()
+    has_permission = permission.has_object_permission(request, None, area_search)
+    assert has_permission is False

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -55,6 +55,7 @@ from plotsearch.models.plot_search import (
     DirectReservationLink,
 )
 from plotsearch.permissions import (
+    AreaSearchPublicPermissions,
     AreaSearchAttachmentPermissions,
     PlotSearchOpeningRecordPermissions,
 )
@@ -297,6 +298,22 @@ class AreaSearchViewSet(viewsets.ModelViewSet):
         )
 
         return response
+
+
+class AreaSearchPublicViewSet(
+    mixins.CreateModelMixin, mixins.UpdateModelMixin, viewsets.GenericViewSet
+):
+    queryset = AreaSearch.objects.all()
+    serializer_class = AreaSearchSerializer
+    permission_classes = (AreaSearchPublicPermissions, IsAuthenticated,)
+    filter_backends = (DjangoFilterBackend, OrderingFilter, InBBoxFilter)
+    filterset_class = AreaSearchFilterSet
+    bbox_filter_field = "geometry"
+    bbox_filter_include_overlapping = True
+
+    def get_permissions(self):
+        permission_classes = [AreaSearchPublicPermissions, IsAuthenticated]
+        return [permission() for permission in permission_classes]
 
 
 class AreaSearchAttachmentViewset(

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -305,15 +305,17 @@ class AreaSearchPublicViewSet(
 ):
     queryset = AreaSearch.objects.all()
     serializer_class = AreaSearchSerializer
-    permission_classes = (AreaSearchPublicPermissions, IsAuthenticated,)
+    permission_classes = (
+        AreaSearchPublicPermissions,
+        IsAuthenticated,
+    )
     filter_backends = (DjangoFilterBackend, OrderingFilter, InBBoxFilter)
     filterset_class = AreaSearchFilterSet
     bbox_filter_field = "geometry"
     bbox_filter_include_overlapping = True
 
     def get_permissions(self):
-        permission_classes = [AreaSearchPublicPermissions, IsAuthenticated]
-        return [permission() for permission in permission_classes]
+        return [permission() for permission in self.permission_classes]
 
 
 class AreaSearchAttachmentViewset(

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -55,8 +55,8 @@ from plotsearch.models.plot_search import (
     DirectReservationLink,
 )
 from plotsearch.permissions import (
-    AreaSearchPublicPermissions,
     AreaSearchAttachmentPermissions,
+    AreaSearchPublicPermissions,
     PlotSearchOpeningRecordPermissions,
 )
 from plotsearch.serializers.plot_search import (


### PR DESCRIPTION
Added new viewset class for the area search public endpoints to only allow adding and updating area searches. Only area searches where there isn't answers are editable.

Relates to Taiga 1951 ticket.