### PR TITLE
Django Auditlog 2.2.2

### DIFF
--- a/credit_integration/views.py
+++ b/credit_integration/views.py
@@ -1,4 +1,3 @@
-from auditlog.middleware import AuditlogMiddleware
 from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -27,7 +26,6 @@ def send_credit_decision_inquiry(request):
     """
     Send credit decision inquiry to credit decision service
     """
-    AuditlogMiddleware().process_request(request)
 
     customer_id = request.data.get("customer_id")
     business_id = request.data.get("business_id")

--- a/leasing/viewsets/area_note.py
+++ b/leasing/viewsets/area_note.py
@@ -7,11 +7,11 @@ from leasing.serializers.area_note import (
     AreaNoteSerializer,
 )
 
-from .utils import AtomicTransactionModelViewSet, AuditLogMixin
+from .utils import AtomicTransactionModelViewSet
 
 
 class AreaNoteViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = AreaNote.objects.all()
     serializer_class = AreaNoteSerializer

--- a/leasing/viewsets/basis_of_rent.py
+++ b/leasing/viewsets/basis_of_rent.py
@@ -10,11 +10,11 @@ from leasing.serializers.basis_of_rent import (
     BasisOfRentSerializer,
 )
 
-from .utils import AtomicTransactionModelViewSet, AuditLogMixin
+from .utils import AtomicTransactionModelViewSet
 
 
 class BasisOfRentViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = BasisOfRent.objects.all()
     serializer_class = BasisOfRentSerializer

--- a/leasing/viewsets/comment.py
+++ b/leasing/viewsets/comment.py
@@ -8,11 +8,11 @@ from leasing.serializers.comment import (
     CommentTopicSerializer,
 )
 
-from .utils import AtomicTransactionModelViewSet, AuditLogMixin
+from .utils import AtomicTransactionModelViewSet
 
 
 class CommentViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = Comment.objects.all().select_related("lease", "user", "topic")
     serializer_class = CommentSerializer
@@ -26,7 +26,7 @@ class CommentViewSet(
 
 
 class CommentTopicViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = CommentTopic.objects.all()
     serializer_class = CommentTopicSerializer

--- a/leasing/viewsets/contact.py
+++ b/leasing/viewsets/contact.py
@@ -6,11 +6,11 @@ from leasing.filters import CoalesceOrderingFilter, ContactFilter
 from leasing.models import Contact
 from leasing.serializers.contact import ContactCreateUpdateSerializer, ContactSerializer
 
-from .utils import AtomicTransactionModelViewSet, AuditLogMixin
+from .utils import AtomicTransactionModelViewSet
 
 
 class ContactViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = Contact.objects.all()
     serializer_class = ContactSerializer

--- a/leasing/viewsets/debt_collection.py
+++ b/leasing/viewsets/debt_collection.py
@@ -21,7 +21,6 @@ from leasing.serializers.debt_collection import (
 )
 from leasing.viewsets.utils import (
     AtomicTransactionModelViewSet,
-    AuditLogMixin,
     FileMixin,
     MultiPartJsonParser,
 )
@@ -29,7 +28,6 @@ from leasing.viewsets.utils import (
 
 class CollectionCourtDecisionViewSet(
     FileMixin,
-    AuditLogMixin,
     FieldPermissionsViewsetMixin,
     AtomicTransactionModelViewSet,
 ):
@@ -47,7 +45,6 @@ class CollectionCourtDecisionViewSet(
 
 class CollectionLetterViewSet(
     FileMixin,
-    AuditLogMixin,
     FieldPermissionsViewsetMixin,
     AtomicTransactionModelViewSet,
 ):
@@ -63,13 +60,13 @@ class CollectionLetterViewSet(
         return CollectionLetterSerializer
 
 
-class CollectionLetterTemplateViewSet(AuditLogMixin, AtomicTransactionModelViewSet):
+class CollectionLetterTemplateViewSet(AtomicTransactionModelViewSet):
     queryset = CollectionLetterTemplate.objects.all()
     serializer_class = CollectionLetterTemplateSerializer
 
 
 class CollectionNoteViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = CollectionNote.objects.all().select_related("user")
     serializer_class = CollectionNoteSerializer

--- a/leasing/viewsets/decision.py
+++ b/leasing/viewsets/decision.py
@@ -14,11 +14,11 @@ from leasing.serializers.decision import (
     DecisionSerializer,
 )
 
-from .utils import AtomicTransactionModelViewSet, AuditLogMixin
+from .utils import AtomicTransactionModelViewSet
 
 
 class DecisionViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = Decision.objects.all()
     serializer_class = DecisionSerializer

--- a/leasing/viewsets/infill_development_compensation.py
+++ b/leasing/viewsets/infill_development_compensation.py
@@ -16,14 +16,13 @@ from leasing.serializers.infill_development_compensation import (
 
 from .utils import (
     AtomicTransactionModelViewSet,
-    AuditLogMixin,
     FileMixin,
     MultiPartJsonParser,
 )
 
 
 class InfillDevelopmentCompensationViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = InfillDevelopmentCompensation.objects.all()
     serializer_class = InfillDevelopmentCompensationSerializer
@@ -112,7 +111,6 @@ class InfillDevelopmentCompensationViewSet(
 
 class InfillDevelopmentCompensationAttachmentViewSet(
     FileMixin,
-    AuditLogMixin,
     FieldPermissionsViewsetMixin,
     AtomicTransactionModelViewSet,
 ):

--- a/leasing/viewsets/inspection.py
+++ b/leasing/viewsets/inspection.py
@@ -7,7 +7,6 @@ from leasing.serializers.inspection import (
 
 from .utils import (
     AtomicTransactionModelViewSet,
-    AuditLogMixin,
     FileMixin,
     MultiPartJsonParser,
 )
@@ -15,7 +14,6 @@ from .utils import (
 
 class InspectionAttachmentViewSet(
     FileMixin,
-    AuditLogMixin,
     FieldPermissionsViewsetMixin,
     AtomicTransactionModelViewSet,
 ):

--- a/leasing/viewsets/land_area.py
+++ b/leasing/viewsets/land_area.py
@@ -17,7 +17,6 @@ from plotsearch.models import PlotSearch, PlotSearchTarget
 
 from .utils import (
     AtomicTransactionModelViewSet,
-    AuditLogMixin,
     FileMixin,
     MultiPartJsonParser,
 )
@@ -25,7 +24,6 @@ from .utils import (
 
 class LeaseAreaAttachmentViewSet(
     FileMixin,
-    AuditLogMixin,
     FieldPermissionsViewsetMixin,
     AtomicTransactionModelViewSet,
 ):

--- a/leasing/viewsets/land_use_agreement.py
+++ b/leasing/viewsets/land_use_agreement.py
@@ -50,7 +50,6 @@ from leasing.serializers.land_use_agreement import (
 
 from .utils import (
     AtomicTransactionModelViewSet,
-    AuditLogMixin,
     FileMixin,
     MultiPartJsonParser,
 )
@@ -133,7 +132,7 @@ def get_values_from_credit_request(data):
 
 
 class LandUseAgreementViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = LandUseAgreement.objects.all()
     serializer_class = LandUseAgreementRetrieveSerializer
@@ -168,7 +167,6 @@ class LandUseAgreementViewSet(
 
 class LandUseAgreementAttachmentViewSet(
     FileMixin,
-    AuditLogMixin,
     FieldPermissionsViewsetMixin,
     AtomicTransactionModelViewSet,
 ):

--- a/leasing/viewsets/lease.py
+++ b/leasing/viewsets/lease.py
@@ -58,7 +58,7 @@ from leasing.serializers.lease import (
 )
 
 from ..permissions import IsMemberOfSameServiceUnit, MvjDjangoModelPermissions
-from .utils import AtomicTransactionModelViewSet, AuditLogMixin
+from .utils import AtomicTransactionModelViewSet
 
 
 class DistrictViewSet(AtomicTransactionModelViewSet):
@@ -137,7 +137,7 @@ class RelatedLeaseViewSet(AtomicTransactionModelViewSet):
 
 
 class LeaseViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     serializer_class = LeaseRetrieveSerializer
     filterset_class = LeaseFilter

--- a/leasing/viewsets/utils.py
+++ b/leasing/viewsets/utils.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from auditlog.middleware import AuditlogMiddleware
 from django.conf import settings
 from django.core.files import File
 from django.db import IntegrityError, transaction
@@ -11,15 +10,6 @@ from rest_framework import parsers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
-
-
-class AuditLogMixin:
-    def initial(self, request, *args, **kwargs):
-        # We need to process logged in user again because Django Rest
-        # Framework handles authentication after the
-        # AuditLogMiddleware.
-        AuditlogMiddleware().process_request(request)
-        return super().initial(request, *args, **kwargs)
 
 
 class AtomicTransactionMixin:

--- a/mvj/settings.py
+++ b/mvj/settings.py
@@ -196,7 +196,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "auditlog.middleware.AuditlogMiddleware",
+    "utils.middleware.CustomAuditlogMiddleware",
 ]
 
 TEMPLATES = [

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -28,7 +28,7 @@ from leasing.permissions import (
     MvjDjangoModelPermissionsOrAnonReadOnly,
     PerMethodPermission,
 )
-from leasing.viewsets.utils import AtomicTransactionModelViewSet, AuditLogMixin
+from leasing.viewsets.utils import AtomicTransactionModelViewSet
 from plotsearch.filter import (
     AreaSearchFilterSet,
     InformationCheckListFilterSet,
@@ -111,7 +111,7 @@ class PlotSearchStageViewSet(
 
 
 class PlotSearchViewSet(
-    AuditLogMixin, FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
+    FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet
 ):
     queryset = PlotSearch.objects.all()
     serializer_class = PlotSearchRetrieveSerializer
@@ -335,7 +335,6 @@ class AreaSearchAttachmentViewset(
 
 
 class InformationCheckViewSet(
-    AuditLogMixin,
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ dataclasses
 deepmerge
 Django~=3.2.23
 django-anymail
-django-auditlog~=1.0a1
+django-auditlog~=2.2.2
 django-admin-rangefilter
 django-jsonfield-compat
 django-constance[database]

--- a/requirements.in
+++ b/requirements.in
@@ -40,7 +40,7 @@ psycopg2-binary
 pysftp
 pyproj
 python-daemon
-python-dateutil
+python-dateutil>=2.7.0
 sentry-sdk
 requests
 typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ django-admin-rangefilter==0.6.3
     # via -r requirements.in
 django-anymail==7.0.0
     # via -r requirements.in
-django-auditlog==1.0a1
+django-auditlog==2.2.2
     # via -r requirements.in
 django-constance[database]==2.7.0
     # via -r requirements.in
@@ -208,7 +208,7 @@ python-bidi==0.4.2
     # via xhtml2pdf
 python-daemon==2.2.4
     # via -r requirements.in
-python-dateutil==2.6.0
+python-dateutil
     # via
     #   -r requirements.in
     #   arrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,8 @@ cryptography==41.0.4
     # via
     #   oracledb
     #   paramiko
+cssselect2==0.7.0
+    # via svglib
 database-sanitizer==1.1.0
     # via django-sanitized-dump
 dataclasses==0.6
@@ -165,6 +167,7 @@ lxml==4.6.5
     # via
     #   docxtpl
     #   python-docx
+    #   svglib
     #   zeep
 markupsafe==1.1.1
     # via jinja2
@@ -196,7 +199,7 @@ pynacl==1.3.0
     # via paramiko
 pyparsing==3.0.6
     # via packaging
-pypdf2==3.0.1
+pypdf3==1.0.6
     # via xhtml2pdf
 pyproj==3.0.1
     # via -r requirements.in
@@ -208,7 +211,7 @@ python-bidi==0.4.2
     # via xhtml2pdf
 python-daemon==2.2.4
     # via -r requirements.in
-python-dateutil
+python-dateutil==2.8.2
     # via
     #   -r requirements.in
     #   arrow
@@ -227,7 +230,9 @@ pyyaml==5.4
     #   django-sanitized-dump
     #   swagger-spec-validator
 reportlab==3.6.13
-    # via xhtml2pdf
+    # via
+    #   svglib
+    #   xhtml2pdf
 requests==2.31.0
     # via
     #   -r requirements.in
@@ -269,18 +274,23 @@ six==1.14.0
     #   python-dateutil
     #   python-jose
     #   swagger-spec-validator
-    #   xhtml2pdf
     #   zeep
 soupsieve==2.0
     # via beautifulsoup4
 sqlparse==0.4.4
     # via django
+svglib==1.5.1
+    # via xhtml2pdf
 swagger-spec-validator==2.7.4
     # via drf-yasg
-typing-extensions==3.10.0.0
+tinycss2==1.2.1
     # via
-    #   -r requirements.in
-    #   pypdf2
+    #   cssselect2
+    #   svglib
+tqdm==4.66.2
+    # via pypdf3
+typing-extensions==3.10.0.0
+    # via -r requirements.in
 uritemplate==3.0.1
     # via
     #   coreapi
@@ -292,7 +302,10 @@ urllib3==1.26.18
 wcwidth==0.1.9
     # via blessed
 webencodings==0.5.1
-    # via html5lib
+    # via
+    #   cssselect2
+    #   html5lib
+    #   tinycss2
 xhtml2pdf==0.2.6
     # via django-xhtml2pdf
 xlsxwriter==1.2.8

--- a/utils/middleware.py
+++ b/utils/middleware.py
@@ -1,0 +1,15 @@
+from auditlog.context import set_actor
+from auditlog.middleware import AuditlogMiddleware
+from django.utils.functional import SimpleLazyObject
+
+
+class CustomAuditlogMiddleware(AuditlogMiddleware):
+    def __call__(self, request):
+        remote_addr = self._get_remote_addr(request)
+
+        user = SimpleLazyObject(lambda: getattr(request, "user", None))
+
+        context = set_actor(actor=user, remote_addr=remote_addr)
+
+        with context:
+            return self.get_response(request)


### PR DESCRIPTION
Update django-auditlog to 2.2.2, together with related packages, to solve the problem with bugs in MVJ2 environment.