### PR TITLE
Fix issue in tests related to leap day

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -281,25 +281,25 @@ def lease_test_data(
             type=TenantContactType.TENANT,
             tenant=tenant1,
             contact=contacts[1],
-            start_date=timezone.now().replace(year=2019).date(),
+            start_date=timezone.datetime(year=2019, month=2, day=28).date(),
         ),
         tenant_contact_factory(
             type=TenantContactType.TENANT,
             tenant=tenant2,
             contact=contacts[2],
-            start_date=timezone.now().replace(year=2019).date(),
+            start_date=timezone.datetime(year=2019, month=2, day=28).date(),
         ),
         tenant_contact_factory(
             type=TenantContactType.CONTACT,
             tenant=tenant2,
             contact=contacts[3],
-            start_date=timezone.now().replace(year=2019).date(),
+            start_date=timezone.datetime(year=2019, month=2, day=28).date(),
         ),
         tenant_contact_factory(
             type=TenantContactType.TENANT,
             tenant=tenant2,
             contact=contacts[4],
-            start_date=timezone.now().date()
+            start_date=timezone.datetime(year=2019, month=3, day=1).date()
             + datetime.timedelta(days=30),  # Future tenant
         ),
     ]

--- a/leasing/tests/api/test_lease_viewset.py
+++ b/leasing/tests/api/test_lease_viewset.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime
+from datetime import datetime
 
 import pytest
 from django.core.serializers.json import DjangoJSONEncoder
@@ -111,7 +111,7 @@ def test_lease_details_contains_future_tenants(
         for tenantcontact in tenant["tenantcontact_set"]:
             if (
                 datetime.strptime(tenantcontact["start_date"], "%Y-%m-%d").date()
-                > date.today()
+                > datetime(year=2019, month=2, day=28).date()
             ):
                 found = True
                 break

--- a/leasing/tests/conftest.py
+++ b/leasing/tests/conftest.py
@@ -827,13 +827,13 @@ def land_use_agreement_test_data(
         type=TenantContactType.TENANT,
         land_use_agreement_litigant=litigants[0],
         contact=contacts[0],
-        start_date=timezone.now().replace(year=2019).date(),
+        start_date=timezone.datetime(year=2019, month=2, day=28).date(),
     ),
     land_use_agreement_litigant_contact_factory(
         type=TenantContactType.TENANT,
         land_use_agreement_litigant=litigants[1],
         contact=contacts[1],
-        start_date=timezone.now().replace(year=2019).date(),
+        start_date=timezone.datetime(year=2019, month=2, day=28).date(),
     ),
 
     land_use_agreement.litigants.set(litigants)


### PR DESCRIPTION
Today is February 29, and tests tried to switch "now" year to a year that does not have a leap day.