### PR TITLE
Set default order for listing area searches in MVJ

### DIFF
--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -270,6 +270,7 @@ class AreaSearchViewSet(viewsets.ModelViewSet):
     }
     filter_backends = (DjangoFilterBackend, OrderingFilter, InBBoxFilter)
     filterset_class = AreaSearchFilterSet
+    ordering = "-received_date"
     bbox_filter_field = "geometry"
     bbox_filter_include_overlapping = True
 


### PR DESCRIPTION
Set returning newest area search first when listing area searches to MVJ.

Relates to Jira ticket MVJ-80