### PR TITLE
Fix issues with ManyToManyField appearint in recursive_get_related

### DIFF
--- a/audittrail/utils.py
+++ b/audittrail/utils.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import OneToOneRel
+from django.db.models import ManyToManyField, OneToOneRel
 
 
 def recursive_get_related(  # NOQA C901
@@ -53,6 +53,10 @@ def recursive_get_related(  # NOQA C901
 
         # Skip relations to a parent model
         if relation.related_model in (po.__class__ for po in parent_objs):
+            continue
+
+        # Skip ManyToManyField that could come via a reverse relation
+        if isinstance(relation, ManyToManyField):
             continue
 
         if relation.concrete or isinstance(relation, OneToOneRel):

--- a/credit_integration/models.py
+++ b/credit_integration/models.py
@@ -105,6 +105,10 @@ class CreditDecision(TimeStampedModel):
         blank=True,
     )
 
+    recursive_get_related_skip_relations = [
+        "reasons",
+    ]
+
     class Meta:
         verbose_name = pgettext_lazy("Model name", "Credit decision")
         verbose_name_plural = pgettext_lazy("Model name", "Credit decisions")


### PR DESCRIPTION
Add skip for `reasons` in CreditDecision, which causes ManyToManyField to appear The case for ManyToManyField is fixed in the recursive function, in case something else is missed