### PR TITLE
area search attachment model permissions

### DIFF
--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -1182,6 +1182,27 @@ DEFAULT_MODEL_PERMS = {
         6: ("view",),
         7: ("view", "add", "change", "delete"),
     },
+    "areasearchattachment": {
+        1: ("view",),
+        2: (
+            "view",
+            "add",
+        ),
+        3: ("view",),
+        4: (
+            "view",
+            "add",
+        ),
+        5: (
+            "view",
+            "add",
+        ),
+        6: ("view",),
+        7: (
+            "view",
+            "add",
+        ),
+    },
     "meetingmemo": {
         1: None,
         2: ("view", "add", "change", "delete"),

--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -1183,25 +1183,13 @@ DEFAULT_MODEL_PERMS = {
         7: ("view", "add", "change", "delete"),
     },
     "areasearchattachment": {
-        1: ("view",),
-        2: (
-            "view",
-            "add",
-        ),
-        3: ("view",),
-        4: (
-            "view",
-            "add",
-        ),
-        5: (
-            "view",
-            "add",
-        ),
-        6: ("view",),
-        7: (
-            "view",
-            "add",
-        ),
+        1: ("view"),
+        2: ("view", "add"),
+        3: ("view"),
+        4: ("view", "add"),
+        5: ("view", "add"),
+        6: ("view"),
+        7: ("view", "add"),
     },
     "meetingmemo": {
         1: None,


### PR DESCRIPTION
In order to open attachments, the user needs permissions for the areasearchattachment model.