### PR TITLE
use invoicing_date to fetch VAT for payment instead of payment_date

### DIFF
--- a/laske_export/management/commands/get_payments_from_laske.py
+++ b/laske_export/management/commands/get_payments_from_laske.py
@@ -281,7 +281,7 @@ class Command(BaseCommand):
                     continue
 
                 if invoice.lease.is_subject_to_vat:
-                    vat = Vat.objects.get_for_date(payment_date)
+                    vat = Vat.objects.get_for_date(invoice.invoicing_date)
                     if not vat:
                         self.stdout.write(
                             "  Lease is subject to VAT but no VAT percent found for payment date {}!".format(


### PR DESCRIPTION
@mikkokeskinen Added you as a reviewer in case you know of some reasoning why payment_date should be used.

VAT is determined in the invoice, and it should not be calculated based on the payment date. When VAT is changing it could lead to different payments having different VAT within the same invoice.

Did not find any mentions in Finnish Tax authoritys documentation that something specific should be used like payment date. https://www.vero.fi/syventavat-vero-ohjeet/ohje-hakusivu/48090/laskutusvaatimukset-arvonlisaverotuksessa3/