### PR TITLE
Remove AreaSearchAttachmentPermissions class

### DIFF
--- a/plotsearch/permissions.py
+++ b/plotsearch/permissions.py
@@ -12,13 +12,6 @@ class AreaSearchPublicPermissions(PerMethodPermission):
         return super().has_object_permission(request, view, obj)
 
 
-class AreaSearchAttachmentPermissions(PerMethodPermission):
-    def has_object_permission(self, request, view, obj):
-        if obj.area_search.user == request.user:
-            return True
-        return super().has_object_permission(request, view, obj)
-
-
 class PlotSearchOpeningRecordPermissions(PerMethodPermission):
     def has_permission(self, request, view):
         if PlotSearch.objects.filter(

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -59,7 +59,6 @@ from plotsearch.models.plot_search import (
     DirectReservationLink,
 )
 from plotsearch.permissions import (
-    AreaSearchAttachmentPermissions,
     AreaSearchPublicPermissions,
     PlotSearchOpeningRecordPermissions,
 )
@@ -375,7 +374,7 @@ class AreaSearchAttachmentViewset(
 ):
     queryset = AreaSearchAttachment.objects.all()
     serializer_class = AreaSearchAttachmentSerializer
-    permission_classes = (AreaSearchAttachmentPermissions,)
+    permission_classes = (PerMethodPermission,)
     perms_map = {
         "GET": ["plotsearch.view_areasearchattachment"],
         "HEAD": ["plotsearch.view_areasearchattachment"],


### PR DESCRIPTION
Previously, area search attachments per-object permissions were limited to the uploader of the attachment. Now even those that haven't uploaded the attachment have permissions to them.