### PR TITLE
Add python version limitation <3.9 for backports-zoneinfo

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ asgiref==3.8.1
     # via
     #   -c requirements.txt
     #   django
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1; python_version < '3.9'
     # via
     #   -c requirements.txt
     #   django

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ attrs==23.2.0
     #   zeep
 babel==2.15.0
     # via docxcompose
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1; python_version < '3.9'
     # via
     #   django
     #   psycopg


### PR DESCRIPTION
This is due to the build failing with e.g. python 3.10. The package is not required after 3.9+, but we have some envs with 3.8 so we need the package. This should then not try to install and build it for python 3.9 and newer.