### PR TITLE
fix signal on plotsearchtarget delete that attempted to access delete…

### DIFF
--- a/plotsearch/signals.py
+++ b/plotsearch/signals.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
@@ -28,8 +29,9 @@ def prepare_plan_unit_on_plot_search_target_save(sender, instance, **kwargs):
 
 @receiver(post_delete, sender=PlotSearchTarget)
 def post_delete_plan_unit_on_plot_search_target_delete(sender, instance, **kwargs):
-    plan_unit = instance.plan_unit
-    if plan_unit is None:
+    try:
+        plan_unit = instance.plan_unit
+    except ObjectDoesNotExist:
         return
     plan_unit.usage_distributions.all().delete()
     plan_unit.delete()


### PR DESCRIPTION
…d planunit

The signal seemingly got triggered on my local when a planunit was deleted, possibly that cascades to deleting plotsearchtarget's - which could be another problem.
This attempts to fix the issue that the signal was attempting to access an attribute that probably was just deleted before.