### PR TITLE
remove distinct() from LeaseViewSet.get_queryset()

### DIFF
--- a/leasing/viewsets/lease.py
+++ b/leasing/viewsets/lease.py
@@ -507,7 +507,7 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
                     service_unit_id__in=search_form.cleaned_data.get("service_unit")
                 )
 
-        return queryset.distinct()
+        return queryset
 
     def get_serializer_class(self):
         if self.action in ("create", "metadata"):


### PR DESCRIPTION
It slows the query down 30-50x, but with testing didn't have an effect on the count of rows returned.