### PR TITLE
Mvj 227 optimize lease list

### DIFF
--- a/leasing/models/lease.py
+++ b/leasing/models/lease.py
@@ -292,11 +292,6 @@ class LeaseManager(SafeDeleteManager):
                 "municipality",
                 "district",
                 "identifier",
-                "identifier__type",
-                "identifier__municipality",
-                "identifier__district",
-                "lessor",
-                "lessor__service_unit",
                 "intended_use",
                 "supportive_housing",
                 "statistical_use",
@@ -306,9 +301,14 @@ class LeaseManager(SafeDeleteManager):
                 "hitas",
                 "notice_period",
                 "preparer",
-                "service_unit",
             )
             .prefetch_related(
+                "service_unit",
+                "identifier__type",
+                "identifier__municipality",
+                "identifier__district",
+                "lessor",
+                "lessor__service_unit",
                 "tenants",
                 "tenants__rent_shares",
                 "tenants__rent_shares__intended_use",
@@ -316,6 +316,7 @@ class LeaseManager(SafeDeleteManager):
                 "tenants__tenantcontact_set__contact",
                 "tenants__tenantcontact_set__contact__service_unit",
                 "lease_areas",
+                "lease_areas__addresses",
                 "contracts",
                 "decisions",
                 "inspections",
@@ -329,7 +330,6 @@ class LeaseManager(SafeDeleteManager):
                 "rents__payable_rents",
                 "rents__fixed_initial_year_rents",
                 "rents__fixed_initial_year_rents__intended_use",
-                "lease_areas__addresses",
                 "basis_of_rents",
                 "collection_letters",
                 "collection_notes",
@@ -339,16 +339,21 @@ class LeaseManager(SafeDeleteManager):
         )
 
     def succinct_select_related_and_prefetch_related(self):
-        return self.get_queryset().select_related(
-            "type",
-            "municipality",
-            "district",
-            "identifier",
-            "identifier__type",
-            "identifier__municipality",
-            "identifier__district",
-            "preparer",
-            "service_unit",
+        return (
+            self.get_queryset()
+            .select_related(
+                "type",
+                "municipality",
+                "district",
+                "identifier",
+                "preparer",
+            )
+            .prefetch_related(
+                "service_unit",
+                "identifier__type",
+                "identifier__municipality",
+                "identifier__district",
+            )
         )
 
     def get_by_identifier(self, identifier):

--- a/leasing/viewsets/lease.py
+++ b/leasing/viewsets/lease.py
@@ -141,15 +141,15 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
     filterset_class = LeaseFilter
     filter_backends = (DjangoFilterBackend, OrderingFilter, InBBoxFilter)
     ordering = (
-        "identifier__type__identifier",
-        "identifier__municipality__identifier",
-        "identifier__district__identifier",
+        "type__identifier",
+        "municipality__identifier",
+        "district__identifier",
         "identifier__sequence",
     )
     ordering_fields = (
-        "identifier__type__identifier",
-        "identifier__municipality__identifier",
-        "identifier__district__identifier",
+        "type__identifier",
+        "municipality__identifier",
+        "district__identifier",
         "identifier__sequence",
         "lessor__name",
         "state",
@@ -199,21 +199,19 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
 
             # Search by identifier or parts of it
             if len(search_string) < 3:
-                identifier_q = Q(
-                    identifier__type__identifier__istartswith=search_string
-                )
+                identifier_q = Q(type__identifier__istartswith=search_string)
             elif len(search_string) == 3:
                 identifier_q = Q(
-                    identifier__type__identifier__iexact=search_string[:2],
-                    identifier__municipality__identifier=search_string[2:3],
+                    type__identifier__iexact=search_string[:2],
+                    municipality__identifier=search_string[2:3],
                 )
             elif len(search_string) < 7:
                 district_identifier = search_string[3:5]
                 if district_identifier == "0":
                     identifier_q = Q(
-                        identifier__type__identifier__iexact=search_string[:2],
-                        identifier__municipality__identifier=search_string[2:3],
-                        identifier__district__identifier__in=range(0, 10),
+                        type__identifier__iexact=search_string[:2],
+                        municipality__identifier=search_string[2:3],
+                        district__identifier__in=range(0, 10),
                     )
                 else:
                     if district_identifier == "00":
@@ -222,9 +220,9 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
                         district_identifier = district_identifier.lstrip("0")
 
                     identifier_q = Q(
-                        identifier__type__identifier__iexact=search_string[:2],
-                        identifier__municipality__identifier=search_string[2:3],
-                        identifier__district__identifier__startswith=district_identifier,
+                        type__identifier__iexact=search_string[:2],
+                        municipality__identifier=search_string[2:3],
+                        district__identifier__startswith=district_identifier,
                     )
             elif looks_like_identifier:
                 district_identifier = search_string[3:5]
@@ -234,9 +232,9 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
                     district_identifier = district_identifier.lstrip("0")
 
                 identifier_q = Q(
-                    identifier__type__identifier__iexact=search_string[:2],
-                    identifier__municipality__identifier=search_string[2:3],
-                    identifier__district__identifier=district_identifier,
+                    type__identifier__iexact=search_string[:2],
+                    municipality__identifier=search_string[2:3],
+                    district__identifier=district_identifier,
                     identifier__sequence__startswith=search_string[6:],
                 )
             else:

--- a/leasing/viewsets/lease.py
+++ b/leasing/viewsets/lease.py
@@ -181,6 +181,9 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
         if self.action != "list":
             return queryset
 
+        # Used for checking were filters added
+        initial_query = str(queryset.query)
+
         # Simple search
         identifier = self.request.query_params.get("identifier")
         search = self.request.query_params.get("search")
@@ -505,7 +508,12 @@ class LeaseViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
                     service_unit_id__in=search_form.cleaned_data.get("service_unit")
                 )
 
-        return queryset.distinct()
+        final_query = str(queryset.query)
+        queryset_has_filters_applied = initial_query != final_query
+        if queryset_has_filters_applied:
+            return queryset.distinct()
+
+        return queryset
 
     def get_serializer_class(self):
         if self.action in ("create", "metadata"):


### PR DESCRIPTION
Another approach for optimizing.
* Shortening path to Leases type, municipality and district by accessing them from Lease, instead of from Lease.identifier (e.g. `Lease.identifier.municipality`).
* Changing ordering fields (**requires change in mvj-ui**) accordingly to :point_up: 
* Attempt to apply `distinct()` only when filters have been added