### PR TITLE
Mvj 329 fix invoice count report

### DIFF
--- a/leasing/report/invoice/laske_invoice_count_report.py
+++ b/leasing/report/invoice/laske_invoice_count_report.py
@@ -81,8 +81,8 @@ class LaskeInvoiceCountReport(ReportBase):
 
         return invoice_counter
 
+    @staticmethod
     def _get_estimate_counts(
-        self,
         original_invoice_counter: Counter,
         today: datetime.date,
         estimate_start_date: datetime.date,

--- a/leasing/report/invoice/laske_invoice_count_report.py
+++ b/leasing/report/invoice/laske_invoice_count_report.py
@@ -1,5 +1,6 @@
 import datetime
 from collections import Counter
+from typing import List, Optional, TypedDict
 
 from dateutil.relativedelta import relativedelta
 from django import forms
@@ -11,6 +12,12 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.models import Invoice, Rent, ServiceUnit
 from leasing.report.report_base import ReportBase
+
+
+class InputData(TypedDict):
+    service_unit: Optional[List[int]]
+    start_date: datetime.date
+    end_date: datetime.date
 
 
 class LaskeInvoiceCountReport(ReportBase):
@@ -31,102 +38,150 @@ class LaskeInvoiceCountReport(ReportBase):
     output_fields = {
         "send_date": {"label": _("Send date"), "format": "date"},
         "invoice_count": {"label": _("Invoice count"), "is_numeric": True},
-        "is_estimate": {"label": _("Estimate"), "format": "boolean"},
+        "estimate_count": {"label": _("Estimated invoice count"), "is_numeric": True},
     }
 
-    def get_data(self, input_data):  # noqa: C901 TODO
+    @staticmethod
+    def _generate_invoice_counter_with_date_keys(query_start_date, query_end_date):
+        invoice_counter = Counter()
+        tmp_date = query_start_date
+        while tmp_date < query_end_date:
+            invoice_counter[tmp_date] = 0
+            tmp_date += datetime.timedelta(days=1)
+        return invoice_counter
+
+    @staticmethod
+    def _get_invoice_counts(
+        original_invoice_counter: Counter,
+        query_start_date: datetime.date,
+        query_end_date: datetime.date,
+        input_data: InputData,
+    ):
+        invoice_counter = original_invoice_counter.copy()
+        invoice_qs = (
+            Invoice.objects.annotate(send_date=TruncDate("sent_to_sap_at"))
+            .filter(
+                sent_to_sap_at__gte=make_aware(
+                    datetime.datetime.combine(query_start_date, datetime.time(0, 0))
+                ),
+                sent_to_sap_at__lte=make_aware(
+                    datetime.datetime.combine(query_end_date, datetime.time(23, 59))
+                ),
+            )
+            .values("send_date")
+            .annotate(invoice_count=Count("id"))
+            .order_by("send_date")
+        )
+
+        if input_data["service_unit"]:
+            invoice_qs = invoice_qs.filter(service_unit__in=input_data["service_unit"])
+
+        for invoice in invoice_qs:
+            invoice_counter[invoice["send_date"]] = invoice["invoice_count"]
+
+        return invoice_counter
+
+    def _get_estimate_counts(
+        self,
+        original_invoice_counter: Counter,
+        today: datetime.date,
+        estimate_start_date: datetime.date,
+        estimate_end_date: datetime.date,
+        input_data: InputData,
+    ):
+        invoice_counter = original_invoice_counter.copy()
+        due_dates_start = estimate_start_date + relativedelta(months=1)
+        due_dates_end = estimate_end_date + relativedelta(months=1)
+
+        rents = (
+            Rent.objects.filter(
+                (Q(end_date__isnull=True) | Q(end_date__gte=estimate_start_date))
+            )
+            .filter(lease__end_date__gte=today, lease__is_invoicing_enabled=True)
+            .select_related("lease", "lease__type")
+        )
+
+        if input_data["service_unit"]:
+            rents = rents.filter(lease__service_unit__in=input_data["service_unit"])
+
+        for rent in rents:
+            due_dates = rent.get_due_dates_for_period(due_dates_start, due_dates_end)
+
+            for due_date in due_dates:
+                invoice_counter[due_date - relativedelta(months=1)] += 1
+
+        invoices = Invoice.objects.filter(
+            due_date__lte=due_dates_end,
+            due_date__gte=due_dates_start,
+            sent_to_sap_at__isnull=True,
+        )
+
+        if input_data["service_unit"]:
+            invoices = invoices.filter(
+                lease__service_unit__in=input_data["service_unit"]
+            )
+
+        for invoice in invoices:
+            invoice_counter[invoice.due_date - relativedelta(months=1)] += 1
+
+        return invoice_counter
+
+    def get_data(self, input_data: InputData):
         today = datetime.date.today()
         query_start_date = min(input_data["start_date"], input_data["end_date"])
         query_end_date = max(input_data["end_date"], input_data["start_date"])
         estimate_start_date = None
         estimate_end_date = None
 
-        data = Counter()
-        tmp_date = query_start_date
-        while tmp_date < query_end_date:
-            data[tmp_date] = 0
-            tmp_date += datetime.timedelta(days=1)
+        invoice_counter = self._generate_invoice_counter_with_date_keys(
+            query_start_date, query_end_date
+        )
 
-        if query_start_date >= today:
+        if query_start_date > today:
+            # Query is in future, only estimates can be provided
             estimate_start_date = query_start_date
             query_start_date = None
             estimate_end_date = query_end_date
             query_end_date = None
-        else:
-            if query_end_date >= today:
-                estimate_start_date = today
-                estimate_end_date = query_end_date
-                query_end_date = today - datetime.timedelta(days=1)
+        elif query_end_date > today:
+            # Query ends in future, provide estimates for dates after today
+            estimate_start_date = today
+            estimate_end_date = query_end_date
+            query_end_date = today
 
         if query_start_date and query_end_date:
-            qs = (
-                Invoice.objects.annotate(send_date=TruncDate("sent_to_sap_at"))
-                .filter(
-                    sent_to_sap_at__gte=make_aware(
-                        datetime.datetime.combine(query_start_date, datetime.time(0, 0))
-                    ),
-                    sent_to_sap_at__lte=make_aware(
-                        datetime.datetime.combine(query_end_date, datetime.time(23, 59))
-                    ),
-                )
-                .values("send_date")
-                .annotate(invoice_count=Count("id"))
-                .order_by("send_date")
+            invoice_counter = self._get_invoice_counts(
+                invoice_counter, query_start_date, query_end_date, input_data
             )
-
-            if input_data["service_unit"]:
-                qs = qs.filter(service_unit__in=input_data["service_unit"])
-
-            for result in qs:
-                data[result["send_date"]] = result["invoice_count"]
 
         if estimate_start_date and estimate_end_date:
-            due_dates_start = estimate_start_date + relativedelta(months=1)
-            due_dates_end = estimate_end_date + relativedelta(months=1)
-
-            rents = (
-                Rent.objects.filter(
-                    (Q(end_date__isnull=True) | Q(end_date__gte=estimate_start_date))
-                )
-                .filter(lease__end_date__gte=today, lease__is_invoicing_enabled=True)
-                .select_related("lease", "lease__type")
+            invoice_counter = self._get_estimate_counts(
+                invoice_counter,
+                today,
+                estimate_start_date,
+                estimate_end_date,
+                input_data,
             )
-
-            if input_data["service_unit"]:
-                rents = rents.filter(lease__service_unit__in=input_data["service_unit"])
-
-            for rent in rents:
-                due_dates = rent.get_due_dates_for_period(
-                    due_dates_start, due_dates_end
-                )
-
-                for due_date in due_dates:
-                    data[due_date - relativedelta(months=1)] += 1
-
-            invoices = Invoice.objects.filter(
-                due_date__lte=due_dates_end,
-                due_date__gte=due_dates_start,
-                sent_to_sap_at__isnull=True,
-            )
-
-            if input_data["service_unit"]:
-                invoices = invoices.filter(
-                    lease__service_unit__in=input_data["service_unit"]
-                )
-
-            for invoice in invoices:
-                data[invoice.due_date - relativedelta(months=1)] += 1
 
         send_dates = []
-        for send_date, invoice_count in data.items():
+        for send_date, invoice_count in invoice_counter.items():
             if invoice_count == 0:
                 continue
-
-            send_dates.append(
-                {
-                    "send_date": send_date,
-                    "invoice_count": invoice_count,
-                    "is_estimate": send_date >= today,
-                }
-            )
+            is_estimate = send_date > today
+            if is_estimate:
+                send_dates.append(
+                    {
+                        "send_date": send_date,
+                        "invoice_count": 0,
+                        "estimate_count": invoice_count,
+                    },
+                )
+            else:
+                send_dates.append(
+                    {
+                        "send_date": send_date,
+                        "invoice_count": invoice_count,
+                        "estimate_count": 0,
+                    },
+                )
         return send_dates

--- a/leasing/tests/report/test_reports.py
+++ b/leasing/tests/report/test_reports.py
@@ -1,15 +1,20 @@
+from datetime import datetime
 from multiprocessing import Event, Value
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.urls import reverse
+from django.utils.timezone import make_aware, now
 from django_q.brokers import get_broker
 from django_q.cluster import monitor, pusher, worker
 from django_q.queues import Queue
 from django_q.tasks import queue_size
 
+from leasing.enums import DueDatesType, InvoiceState
+from leasing.report.invoice.laske_invoice_count_report import LaskeInvoiceCountReport
 from leasing.report.lease.lease_statistic_report import LeaseStatisticReport
 from leasing.report.viewset import ENABLED_REPORTS
 
@@ -128,3 +133,98 @@ def test_report_list(client, user):
     assert len(data) == 3
 
     assert {r.slug for r in ENABLED_REPORTS[-3:]} == set(data.keys())
+
+
+@pytest.mark.django_db
+def test_laske_invoice_count_report(
+    client,
+    user,
+    invoice_factory,
+    service_unit_factory,
+    lease_factory,
+    contact_factory,
+    rent_factory,
+):
+    _add_report_permission(user, LaskeInvoiceCountReport)
+    client.force_login(user)
+
+    service_unit = service_unit_factory()
+    lease = lease_factory(
+        service_unit=service_unit, is_invoicing_enabled=True, end_date="2030-12-31"
+    )
+    contact = contact_factory()
+    dates = [
+        make_aware(datetime(2024, 6, 13)),
+        make_aware(datetime(2024, 6, 14)),
+        make_aware(datetime(2024, 6, 15)),
+    ]
+    for date in dates:
+        invoice_factory.create(
+            state=InvoiceState.OPEN,
+            sent_to_sap_at=date,
+            lease=lease,
+            service_unit=service_unit,
+            recipient=contact,
+            total_amount=1000,
+            billed_amount=1000,
+        )
+
+    # Create rent that should generate future invoices, to be listed in estimated_count
+    rent_factory(
+        lease=lease,
+        start_date=make_aware(datetime(2024, 1, 1)),
+        end_date=None,
+        due_dates_type=DueDatesType.FIXED,
+        due_dates_per_year=12,  # Monthly invoices, expected at the beginning of the month
+    )
+    # Create invoice in the future, to be listed in estimated_count
+    invoice_factory(
+        state=InvoiceState.OPEN,
+        sent_to_sap_at=None,
+        lease=lease,
+        service_unit=service_unit,
+        recipient=contact,
+        total_amount=1000,
+        billed_amount=1000,
+        due_date=make_aware(datetime(2024, 7, 16)),
+    )
+
+    with patch("leasing.report.invoice.laske_invoice_count_report.now") as mock_now:
+        # Freeze "today" to 2024-06-15 08:01:01 in django.utils.timezone.now() used in code
+        mock_now.return_value = now().replace(
+            year=2024, month=6, day=15, hour=8, minute=1, second=1
+        )
+
+        url = reverse(
+            "v1:report-detail",
+            kwargs={
+                "report_type": LaskeInvoiceCountReport.slug,
+            },
+        )
+        query_params = {
+            "start_date": "2024-06-13",
+            "end_date": "2024-08-18",
+            "service_unit": service_unit.id,
+        }
+        response = client.get(url, data=query_params)
+
+    assert response.status_code == 200
+
+    response_data_dict = {
+        item["send_date"].isoformat(): {
+            "invoice_count": item["invoice_count"],
+            "estimate_count": item["estimate_count"],
+        }
+        for item in response.data
+    }
+
+    assert response_data_dict == {
+        "2024-06-13": {"invoice_count": 1, "estimate_count": 0},
+        "2024-06-14": {"invoice_count": 1, "estimate_count": 0},
+        "2024-06-15": {"invoice_count": 1, "estimate_count": 0},
+        # Manually created invoice not yet sent to SAP
+        "2024-06-16": {"invoice_count": 0, "estimate_count": 1},
+        # Invoices coming from rent
+        "2024-07-01": {"invoice_count": 0, "estimate_count": 1},
+        "2024-08-01": {"invoice_count": 0, "estimate_count": 1},
+    }

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-12 14:23+0200\n"
+"POT-Creation-Date: 2024-06-14 18:00+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: fi\n"
@@ -15,6 +15,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "View auditlog"
+msgstr "Näytä auditointiloki"
+
+msgid "View auditlog of a lease or a contact"
+msgstr "Näytä valitun vuokrauksen tai asiakkaan auditointiloki"
 
 msgid "executable or script"
 msgstr "Ajettava tiedosto"
@@ -147,6 +153,9 @@ msgstr "Aikavyöhyke"
 
 msgid "timezones"
 msgstr "Aikavyöhykkeet"
+
+msgid "Timezone name can't be empty"
+msgstr ""
 
 msgid "Invalid timezone name"
 msgstr "Epäkelpo aikavyöhykkeen nimi"
@@ -482,11 +491,11 @@ msgstr "Lasku"
 msgid "Invoices"
 msgstr "Laskut"
 
-msgid "Lease"
-msgstr "Vuokraus"
-
 msgid "Lease identifier"
 msgstr "Vuokraustunnus"
+
+msgid "Invoice number"
+msgstr "Laskun numero"
 
 msgid "Due date"
 msgstr "Eräpäivä"
@@ -614,6 +623,9 @@ msgstr "Laske-maksujen loki"
 msgctxt "Model name"
 msgid "Laske payments logs"
 msgstr "Laske-maksujen lokit"
+
+msgid "Lease"
+msgstr "Vuokraus"
 
 msgid "Search by identifier"
 msgstr "Etsi tunnisteella"
@@ -2403,6 +2415,9 @@ msgctxt "Model name"
 msgid "Leases"
 msgstr "Vuokraukset"
 
+msgid "The intended use's service unit must match the lease's service_unit."
+msgstr "Käyttötarkoituksen ja vuokrauksen palvelukokonaisuuden pitää olla sama."
+
 #, python-brace-format
 msgid "{area_identifier}, {area_addresses}, {area_m2}m2"
 msgstr "{area_identifier}, {area_addresses}, {area_m2}m2"
@@ -2935,9 +2950,6 @@ msgid ""
 "Show all the payments that have been paid between the start and the end date"
 msgstr "Näytä maksusuoritukset, jotka on maksettu alkupvm ja loppupvm välillä"
 
-msgid "Invoice number"
-msgstr "Laskun numero"
-
 msgid "Total"
 msgstr "Yhteensä"
 
@@ -3023,8 +3035,8 @@ msgstr ""
 msgid "Send date"
 msgstr "Lähetyspvm"
 
-msgid "Estimate"
-msgstr "Arvio"
+msgid "Estimated invoice count"
+msgstr "Tulevien laskujen arvioitu määrä"
 
 msgid "Open invoices"
 msgstr "Avoimet laskut"
@@ -3410,12 +3422,6 @@ msgstr "Y-tunnus on viallinen"
 
 msgid "File not available"
 msgstr "Tiedostoa ei löydy"
-
-msgid "View auditlog"
-msgstr "Näytä auditointiloki"
-
-msgid "View auditlog of a lease or a contact"
-msgstr "Näytä valitun vuokrauksen tai asiakkaan auditointiloki"
 
 msgid "Check if contact already exist"
 msgstr "Tarkista onko kontakti jo olemassa"

--- a/utils/management/commands/app_makemessages.py
+++ b/utils/management/commands/app_makemessages.py
@@ -2,7 +2,13 @@ from django.core.management.commands import makemessages
 
 
 class Command(makemessages.Command):
-    msgmerge_options = ["-q", "--previous", "--no-fuzzy-matching"]
+    msgmerge_options = [
+        "-q",
+        "--previous",
+        "--update",
+        "--backup=none",
+        "--no-fuzzy-matching",
+    ]
 
     def handle(self, *args, **options):
         options["no_location"] = True


### PR DESCRIPTION
Sorry for including my refactoring together with the fix.

The fix was basically in the two if's
* `if query_start_date >= today:` -> `if query_start_date > today:`
* `else: if query_end_date >= today:` -> ` elif query_end_date > today:`

It was switching todays invoices to become estimates, and in the report there was only a column `is_estimate` which I removed, and included the estimated count instead when it is available. I believe this caused confusion among the users who tough the **estimated invoice counts** were actually sent invoice counts.
Lots of reports were about the todays invoice count changing _tomorrow_, I believe this was the likely cause.