### PR TITLE
Contact rents fixes

### DIFF
--- a/leasing/report/lease/contact_rents.py
+++ b/leasing/report/lease/contact_rents.py
@@ -37,8 +37,8 @@ class ContactRentsReport(ReportBase):
             "source": get_lease_area_identifier,
             "width": 20,
         },
-        "start_date": {"label": "Start date"},
-        "end_date": {"label": "End date"},
+        "start_date": {"label": _("Start date")},
+        "end_date": {"label": _("End date")},
         "address": {"label": _("Address"), "source": get_address, "width": 20},
         "tenants": {"label": _("Tenants"), "source": get_tenants, "width": 40},
         "rent_amount": {

--- a/leasing/report/lease/contact_rents.py
+++ b/leasing/report/lease/contact_rents.py
@@ -37,8 +37,8 @@ class ContactRentsReport(ReportBase):
             "source": get_lease_area_identifier,
             "width": 20,
         },
-        "start_date": {"label": _("Start date")},
-        "end_date": {"label": _("End date")},
+        "start_date": {"label": _("Start date"), "format": "date"},
+        "end_date": {"label": _("End date"), "format": "date"},
         "address": {"label": _("Address"), "source": get_address, "width": 20},
         "tenants": {"label": _("Tenants"), "source": get_tenants, "width": 40},
         "rent_amount": {


### PR DESCRIPTION
Contact rents (Asiakkaalta perittävät vuokrat) had start date and end date column titles in English, and their formatting was off (it also obscured the dates completely in the Excel file, showing only some numbers). Now those issues are fixed by adding translation and formatting to the output fields.