### PR TITLE
fix collections import

### DIFF
--- a/leasing/management/commands/set_group_field_permissions.py
+++ b/leasing/management/commands/set_group_field_permissions.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 
 from django.apps import apps
 from django.contrib.auth.models import Group, Permission
@@ -549,7 +549,7 @@ CUSTOM_FIELD_PERMS = {
 
 def update(d, u):
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, Mapping):
             d[k] = update(d.get(k, {}), v)
         else:
             d[k] = v


### PR DESCRIPTION
When running the `python manage.py set_group_field_permissions` in the devcontainer, it gave this error:

`set_group_field_permissions.py:552: AttributeError: module 'collections' has no attribute 'Mapping'`

These changes fix this issue.