### PR TITLE
[WIP] MVJ-357 KUVA decision makers data

### DIFF
--- a/leasing/fixtures/decision_maker.json
+++ b/leasing/fixtures/decision_maker.json
@@ -1158,40 +1158,96 @@
     "model": "leasing.DecisionMaker",
     "pk": 166,
     "fields": {
-      "name": "Kulttuuri- ja vapaa-aikalautakunta"
+      "name": "Make sähköposti"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 167,
     "fields": {
-      "name": "Liikuntajohtaja"
+      "name": "Kiinteistöjen kehittäminen - tiimipäällikkö"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 168,
     "fields": {
-      "name": "Liikuntapaikkapäällikkö"
+      "name": "Maaomaisuuden hallinnan tuki -yksikön päällikkö"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 169,
     "fields": {
-      "name": "Ulkoilupalvelupäällikkö"
+      "name": "Kaupunkiympäristölautakunnan ympäristö- ja lupajaosto"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 170,
     "fields": {
-      "name": "Nuorisoasiainjohtaja"
+      "name": "Ympäristöseuranta ja valvonta - Yksikön päällikkö"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 171,
+    "fields": {
+      "name": "Tapahtumat ja maanvuokraus - tiimipäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 172,
+    "fields": {
+      "name": "Kaupunkiympäristölautakunnan rakennusten ja yleisten alueiden jaosto"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 173,
+    "fields": {
+      "name": "Ympäristöpalvelut, Vesi - tiimipäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 174,
+    "fields": {
+      "name": "Kulttuuri- ja vapaa-aikalautakunta"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 175,
+    "fields": {
+      "name": "Liikuntajohtaja"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 176,
+    "fields": {
+      "name": "Liikuntapaikkapäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 177,
+    "fields": {
+      "name": "Ulkoilupalvelupäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 178,
+    "fields": {
+      "name": "Nuorisoasiainjohtaja"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 179,
     "fields": {
       "name": "Aluepäällikkö"
     }

--- a/leasing/fixtures/decision_maker.json
+++ b/leasing/fixtures/decision_maker.json
@@ -1153,5 +1153,47 @@
     "fields": {
       "name": "Ympäristövalvontapäällikkö"
     }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 166,
+    "fields": {
+      "name": "Kulttuuri- ja vapaa-aikalautakunta"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 167,
+    "fields": {
+      "name": "Liikuntajohtaja"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 168,
+    "fields": {
+      "name": "Liikuntapaikkapäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 169,
+    "fields": {
+      "name": "Ulkoilupalvelupäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 170,
+    "fields": {
+      "name": "Nuorisoasiainjohtaja"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 171,
+    "fields": {
+      "name": "Aluepäällikkö"
+    }
   }
 ]

--- a/leasing/fixtures/decision_maker.json
+++ b/leasing/fixtures/decision_maker.json
@@ -1214,40 +1214,54 @@
     "model": "leasing.DecisionMaker",
     "pk": 174,
     "fields": {
-      "name": "Kulttuuri- ja vapaa-aikalautakunta"
+      "name": "Oikeuspalvelut"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 175,
     "fields": {
-      "name": "Liikuntajohtaja"
+      "name": "Toimitilatontit ja kiinteistökehitys -tiimipäällikkö"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 176,
     "fields": {
-      "name": "Liikuntapaikkapäällikkö"
+      "name": "Kulttuuri- ja vapaa-aikalautakunta"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 177,
     "fields": {
-      "name": "Ulkoilupalvelupäällikkö"
+      "name": "Liikuntajohtaja"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 178,
     "fields": {
-      "name": "Nuorisoasiainjohtaja"
+      "name": "Liikuntapaikkapäällikkö"
     }
   },
   {
     "model": "leasing.DecisionMaker",
     "pk": 179,
+    "fields": {
+      "name": "Ulkoilupalvelupäällikkö"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 180,
+    "fields": {
+      "name": "Nuorisoasiainjohtaja"
+    }
+  },
+  {
+    "model": "leasing.DecisionMaker",
+    "pk": 181,
     "fields": {
       "name": "Aluepäällikkö"
     }


### PR DESCRIPTION
Add new KUVA decision makers to the fixtures. 

It also needs to be ensured if the following decision makers should be added to the fixtures as well. At least they exist in dev database but are missing in the fixtures:

```code
Make sähköposti
Kiinteistöjen kehittäminen - tiimipäällikkö
Maaomaisuuden hallinnan tuki -yksikön päällikkö
Kaupunkiympäristölautakunnan ympäristö- ja lupajaosto
Ympäristöseuranta ja valvonta - Yksikön päällikkö
Tapahtumat ja maanvuokraus - tiimipäällikkö
Kaupunkiympäristölautakunnan rakennusten ja yleisten alueiden jaosto
Ympäristöpalvelut, Vesi - tiimipäällikkö
```