### PR TITLE
Statistics report I: Show future tenant if only one

### DIFF
--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -15,19 +15,24 @@ def get_lease_id(lease):
     return lease.get_identifier_string()
 
 
-def get_tenants(lease, include_future_tenants=False):
+def get_tenants(lease, include_future_tenants=False, report=None):
     today = datetime.date.today()
 
     contacts = set()
 
     for tenant in lease.tenants.all():
-        for tc in tenant.tenantcontact_set.all():
+        all_tenantcontacts = tenant.tenantcontact_set.all()
+        for tc in all_tenantcontacts:
+            if report == "Lease statistics report" and len(all_tenantcontacts) == 1:
+                include_future_tenants = True
+
             if tc.type != TenantContactType.TENANT:
                 continue
 
             if (tc.end_date is None or tc.end_date >= today) and (
                 include_future_tenants
-                or (tc.start_date is None or tc.start_date <= today)
+                or tc.start_date is None
+                or tc.start_date <= today
             ):
                 contacts.add(tc.contact)
 

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -29,7 +29,7 @@ from leasing.report.lease.common_getters import (
     get_tenants,
     get_total_area,
 )
-from leasing.report.report_base import ReportBase
+from leasing.report.report_base import AsyncReportBase
 
 # TODO: Can we get rid of static ids
 RESIDENTIAL_INTENDED_USE_IDS = [
@@ -192,7 +192,7 @@ def get_average_amount_per_area_business(obj):
     )
 
 
-class LeaseStatisticReport(ReportBase):
+class LeaseStatisticReport(AsyncReportBase):
     name = _("Lease statistics report")
     description = _(
         "Shows information about all leases or if start date is provided the leases that have started on or after it"

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -29,7 +29,7 @@ from leasing.report.lease.common_getters import (
     get_tenants,
     get_total_area,
 )
-from leasing.report.report_base import AsyncReportBase
+from leasing.report.report_base import ReportBase
 
 # TODO: Can we get rid of static ids
 RESIDENTIAL_INTENDED_USE_IDS = [
@@ -192,7 +192,7 @@ def get_average_amount_per_area_business(obj):
     )
 
 
-class LeaseStatisticReport(AsyncReportBase):
+class LeaseStatisticReport(ReportBase):
     name = _("Lease statistics report")
     description = _(
         "Shows information about all leases or if start date is provided the leases that have started on or after it"
@@ -245,7 +245,13 @@ class LeaseStatisticReport(AsyncReportBase):
         # Rakennuttaja
         "real_estate_developer": {"label": _("Real estate developer"), "width": 20},
         # Vuokralaiset
-        "tenants": {"label": _("Tenants"), "source": get_tenants, "width": 40},
+        "tenants": {
+            "label": _("Tenants"),
+            "source": lambda x: get_tenants(
+                x, include_future_tenants=False, report="Lease statistics report"
+            ),
+            "width": 40,
+        },
         # Start date
         "start_date": {"label": _("Start date"), "format": "date"},
         # End date


### PR DESCRIPTION
The "Vuokralaiset" field used to be empty if the "Alkupvm" (start date of the tenantcontact" was in the future. Now the tenant name is shown even if it is in the future and if there is only one tenant for that lease.

![image](https://github.com/City-of-Helsinki/mvj/assets/83913239/35635b19-eb6f-440f-bacd-c6982c0e7c55)
