### PR TITLE
Include internal order for KUVA receivable types

### DIFF
--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -8,6 +8,8 @@ from leasing.models.utils import get_next_business_day, is_business_day
 
 from .sales_order import BillingParty1, LineItem, OrderParty
 
+KUVA_LASKE_SALES_ORG = "2900"
+
 
 class InvoiceSalesOrderAdapter:
     def __init__(
@@ -200,8 +202,9 @@ class InvoiceSalesOrderAdapter:
             # "rent" and the internal order is set.
             if (
                 receivable_type == self.receivable_type_rent
-                and self.invoice.lease.internal_order
-            ):
+                or self.invoice.lease.service_unit.laske_sales_org
+                == KUVA_LASKE_SALES_ORG
+            ) and self.invoice.lease.internal_order:
                 line_item.order_item_number = self.invoice.lease.internal_order
 
             line_item.quantity = "1,00"


### PR DESCRIPTION
Currently, the internal_order is included in the invoices only if the receivable type is 'Maanvuokraus'. 

In this change, a case is added where the service unit is one of KUVA service units, and the receivable type is one of those that will need the internal_order number included with the invoice data that is exported to SAP.