### PR TITLE
Decision conditions report: filter out deleted leases

### DIFF
--- a/leasing/report/lease/decision_conditions_report.py
+++ b/leasing/report/lease/decision_conditions_report.py
@@ -100,6 +100,7 @@ class DecisionConditionsReport(ReportBase):
         qs = (
             Condition.objects.filter(supervised_date__isnull=True)
             .exclude(deleted__isnull=False)
+            .exclude(decision__lease__deleted__isnull=False)
             .select_related(
                 "type",
                 "decision",


### PR DESCRIPTION
The decision conditions (Päätöksen ehdot) report filtered out deleted decision conditions, but not deleted leases.

Now deleted leases are excluded as well.