### PR TITLE
Rent adjustment report: exclude if rent OR lease is deleted

### DIFF
--- a/leasing/report/lease/rent_adjustments.py
+++ b/leasing/report/lease/rent_adjustments.py
@@ -97,7 +97,7 @@ class RentAdjustmentsReport(ReportBase):
                 Q(end_date__isnull=True) | Q(end_date__gte=today),
                 Q(rent__lease__end_date__isnull=True)
                 | Q(rent__lease__end_date__gte=today),
-                Q(rent__deleted__isnull=True) & Q(rent__lease__deleted__isnull=True),
+                Q(rent__deleted__isnull=True) | Q(rent__lease__deleted__isnull=True),
             )
             .select_related(
                 "intended_use",


### PR DESCRIPTION
Previously, the filtering required both lease and rent to be deleted to exclude the rent adjustment from the reports. But if the rent is deleted, so must the rent adjustment. And if the whole lease is deleted, so must the rent and the rent adjustment be excluded from the report.