### PR TITLE
Mvj 321 leases by leasetype

### DIFF
--- a/leasing/report/lease/rent_type.py
+++ b/leasing/report/lease/rent_type.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Protocol
 
 from django import forms
 from django.db.models import CharField, Q
@@ -10,21 +11,25 @@ from leasing.models import Rent, ServiceUnit
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_id(obj):
+class RentWithContactNames(Protocol):
+    contact_names: str
+
+
+def get_lease_id(obj: Rent):
     return obj.lease.get_identifier_string()
 
 
-def get_tenants(obj):
+def get_tenants(obj: RentWithContactNames) -> str:
     return obj.contact_names
 
 
-def get_area_id(obj):
+def get_area_id(obj: Rent):
     return ", ".join(
         [la.identifier for la in obj.lease.lease_areas.all() if la.archived_at is None]
     )
 
 
-def get_contract_number(obj):
+def get_contract_number(obj: Rent):
     contract_numbers = []
     for contract in obj.lease.contracts.all():
         if not contract.contract_number:
@@ -33,7 +38,7 @@ def get_contract_number(obj):
     return " / ".join(contract_numbers)
 
 
-def get_area_address(obj):
+def get_area_address(obj: Rent):
     addresses = []
     for lease_area in obj.lease.lease_areas.all():
         if lease_area.archived_at:
@@ -45,24 +50,24 @@ def get_area_address(obj):
     return ", ".join(addresses)
 
 
-def get_municipality(obj):
+def get_municipality(obj: Rent):
     return obj.lease.municipality.name
 
 
-def get_start_date(obj):
+def get_start_date(obj: Rent):
     return obj.lease.start_date
 
 
-def get_end_date(obj):
+def get_end_date(obj: Rent):
     return obj.lease.end_date
 
 
-def get_intended_use(obj):
+def get_intended_use(obj: Rent):
     iu = obj.lease.intended_use
     return iu.name if iu else "-"
 
 
-def get_rent_type(obj):
+def get_rent_type(obj: Rent):
     return str(obj.type.label)
 
 

--- a/leasing/report/lease/rent_type.py
+++ b/leasing/report/lease/rent_type.py
@@ -1,10 +1,11 @@
 import datetime
 
 from django import forms
-from django.db.models import Q
+from django.db.models import CharField, Q
+from django.db.models.expressions import RawSQL
 from django.utils.translation import gettext_lazy as _
 
-from leasing.enums import RentType, TenantContactType
+from leasing.enums import ContactType, RentType, TenantContactType
 from leasing.models import Rent, ServiceUnit
 from leasing.report.report_base import ReportBase
 
@@ -14,17 +15,7 @@ def get_lease_id(obj):
 
 
 def get_tenants(obj):
-    today = datetime.date.today()
-    contacts = set()
-    for tenant in obj.lease.tenants.all():
-        for tc in tenant.tenantcontact_set.all():
-            if tc.type != TenantContactType.TENANT:
-                continue
-            if (tc.end_date is None or tc.end_date >= today) and (
-                tc.start_date is None or tc.start_date <= today
-            ):
-                contacts.add(tc.contact)
-    return ", ".join([c.get_name() for c in contacts])
+    return obj.contact_names
 
 
 def get_area_id(obj):
@@ -94,7 +85,11 @@ class RentTypeReport(ReportBase):
     }
     output_fields = {
         "lease_id": {"source": get_lease_id, "label": _("Lease id")},
-        "tenant_name": {"source": get_tenants, "label": _("Tenant name"), "width": 50},
+        "tenant_name": {
+            "source": get_tenants,
+            "label": _("Tenant name"),
+            "width": 50,
+        },
         "lease_area_identifier": {
             "source": get_area_id,
             "label": _("Lease area identifier"),
@@ -122,6 +117,29 @@ class RentTypeReport(ReportBase):
     }
 
     def get_data(self, input_data):
+        current_date = datetime.date.today()
+        # RawSQL is used in order to make the report load faster, it was and still is extremely slow with 10k+ entries
+        # This SQL uses PostgreSQL expression STRING_AGG to concatenate contact names into a single string
+        # The CASE statement is used to to select the name in SQL instead of doing it in Django
+        contact_names_concat_sql = """
+        SELECT STRING_AGG(contact_name, ', ' ORDER BY contact_name)
+        FROM (
+            SELECT DISTINCT
+                CASE
+                    WHEN leasing_contact.type = %s
+                        THEN leasing_contact.first_name || ' ' || leasing_contact.last_name
+                    ELSE leasing_contact.name
+                END AS contact_name
+            FROM leasing_contact
+            JOIN leasing_tenantcontact ON leasing_tenantcontact.contact_id = leasing_contact.id
+            JOIN leasing_tenant ON leasing_tenantcontact.tenant_id = leasing_tenant.id
+            WHERE
+                leasing_tenant.lease_id = leasing_rent.lease_id
+                AND leasing_tenantcontact.type = %s
+                AND (leasing_tenantcontact.start_date IS NULL OR leasing_tenantcontact.start_date <= %s)
+                AND (leasing_tenantcontact.end_date IS NULL OR leasing_tenantcontact.end_date >= %s)
+        ) AS distinct_contacts
+        """
         qs = (
             Rent.objects.filter(
                 type=input_data["rent_type"], lease__deleted__isnull=True
@@ -136,12 +154,21 @@ class RentTypeReport(ReportBase):
                 "lease__intended_use",
             )
             .prefetch_related(
-                "lease__tenants",
-                "lease__tenants__tenantcontact_set",
-                "lease__tenants__tenantcontact_set__contact",
                 "lease__lease_areas",
                 "lease__lease_areas__addresses",
                 "lease__contracts",
+            )
+            .annotate(
+                contact_names=RawSQL(
+                    sql=contact_names_concat_sql,
+                    params=(
+                        ContactType.PERSON.value,
+                        TenantContactType.TENANT.value,
+                        current_date,
+                        current_date,
+                    ),
+                    output_field=CharField(),
+                )
             )
             .order_by(
                 "lease__identifier__municipality__identifier",
@@ -156,8 +183,7 @@ class RentTypeReport(ReportBase):
 
         if input_data["only_active_leases"]:
             qs = qs.filter(
-                Q(lease__end_date__isnull=True)
-                | Q(lease__end_date__gte=datetime.date.today())
+                Q(lease__end_date__isnull=True) | Q(lease__end_date__gte=current_date)
             )
 
         return qs

--- a/leasing/report/report_base.py
+++ b/leasing/report/report_base.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from typing import Union
 
 import xlsxwriter
 from django.conf import settings
@@ -6,6 +7,7 @@ from django.core.mail import EmailMessage
 from django.db.models import Model, QuerySet
 from django.forms.models import ModelChoiceIteratorValue
 from django.utils import timezone
+from django.utils.functional import Promise
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from django_q.conf import Conf
@@ -21,13 +23,13 @@ from leasing.report.serializers import ReportOutputSerializer
 
 class ReportBase:
     # Name is returned in the report list and in the metadata
-    name = None
+    name: Union[str, Promise, None] = None
 
     # Description is returned in the report list and in the metadata
-    description = None
+    description: Union[str, Promise, None] = None
 
     # Slug is the id of the report
-    slug = None
+    slug: Union[str, None] = None
 
     # Input fields are form fields that are used to validate the input
     # parameters. The form's validated_data is passed to get_data function.


### PR DESCRIPTION
First commit includes logic changes, second commit adds basic typing (you can review them separately).

Suboptimal solution, but seems to be much faster than previously. I suspect the slowness comes from serializing many thousands of objects. I got this response to go under 1.8minutes with my local dataset for `Index (old)`.

RawSQL was used together with STRING_AGG which is a Postgresql specific functionality. This is not optimal, but I couldn't get things to work simply with django querysets. I tried Subqueries with OuterRef, but couldn't get it to work to gather multiple names.