### PR TITLE
Active rents must have lease active

### DIFF
--- a/leasing/models/lease.py
+++ b/leasing/models/lease.py
@@ -869,6 +869,8 @@ class Lease(TimeStampedSafeDeleteModel):
         rent_range_filter = Q(
             Q(Q(end_date=None) | Q(end_date__gte=date_range_start))
             & Q(Q(start_date=None) | Q(start_date__lte=date_range_end))
+            & Q(Q(lease__end_date=None) | Q(lease__end_date__gte=date_range_start))
+            & Q(Q(lease__start_date=None) | Q(lease__start_date__lte=date_range_end))
         )
 
         return self.rents.filter(rent_range_filter)


### PR DESCRIPTION
Active rents of a lease have been determined only by the rent's own start and end dates. This means that the rent could have been counted active even in cases where the lease had ended. This has caused strange discrepancies in the rent forecast report (vuokraennuste).

With this change, the related lease must be active in order for the rent to be active.