### PR TITLE
fix intended use filter to use search as query param name

### DIFF
--- a/leasing/filters.py
+++ b/leasing/filters.py
@@ -142,9 +142,12 @@ class IndexFilter(FilterSet):
 
 
 class IntendedUseFilter(FilterSet):
+    # For some reason the field `name` does not work for filtering
+    search = filters.CharFilter(field_name="name_fi", lookup_expr="icontains")
+
     class Meta:
         model = IntendedUse
-        fields = ["service_unit", "name"]
+        fields = ["service_unit"]
 
 
 class InvoiceFilter(FilterSet):


### PR DESCRIPTION
for some unknown reason the filter for name does not work. tried debugging it but found no reason, it is likely related to the fact that the field is translated. using finnish translated field for now.