### PR TITLE
MVJ-408: Unify invoicing disabled reports

### DIFF
--- a/leasing/report/utils.py
+++ b/leasing/report/utils.py
@@ -1,0 +1,5 @@
+# From Django docs
+def dictfetchall(cursor):
+    """Return all rows from a cursor as a dict"""
+    columns = [col[0] for col in cursor.description]
+    return [dict(zip(columns, row)) for row in cursor.fetchall()]


### PR DESCRIPTION
Leases with invoicing disabled is reported in two places: as a section in invoicing review report and as a separate report, invoicing_disabled_report. They have different code for doing the same thing.

This fix creates one SQL query string to be used in both places.