### PR TITLE
fix TextJSONField issue that causes TypeError when accessing it

### DIFF
--- a/batchrun/fields.py
+++ b/batchrun/fields.py
@@ -52,3 +52,16 @@ class IntegerSetSpecifierField(models.CharField):  # type: ignore
 class TextJSONField(JSONField):
     def db_type(self, connection: Any) -> str:
         return "json"
+
+    def from_db_value(self, value, expression, connection):
+        """
+        This is a workaround to make this field work with Django.
+        Changing the db_type to "json" causes the issue that this
+        field can't even be accessed and raises a TypeError.
+        """
+        # Seems like setting db_type to "json" gives back value that is a dict.
+        if isinstance(value, dict):
+            return value
+
+        value = super().from_db_value(value, expression, connection)
+        return value

--- a/batchrun/tests/test_models.py
+++ b/batchrun/tests/test_models.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+import pytest
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
+
+from batchrun.models import JobRun
+
+
+@pytest.mark.django_db
+def test_jobrunlog_delete(job_run_log_factory):
+    jobrunlog_entry_dict = job_run_log_factory(
+        start=timezone.now() - timedelta(hours=1),
+        end=timezone.now(),
+        entry_count=100,
+        error_count=1,
+        content="test content",
+        entry_data={"test": "data"},
+    )
+
+    jobrun_dict: JobRun = JobRun.objects.get(pk=jobrunlog_entry_dict.run.pk)
+    assert jobrun_dict.log is not None
+    jobrun_dict.delete_logs()
+    jobrun_dict.refresh_from_db()
+    with pytest.raises(ObjectDoesNotExist):
+        jobrun_dict.log
+
+    jobrunlog_entry_json = job_run_log_factory(
+        start=timezone.now() - timedelta(hours=1),
+        end=timezone.now(),
+        entry_count=100,
+        error_count=1,
+        content="test content",
+        entry_data='{"test": "data"}',
+    )
+
+    jobrun_json: JobRun = JobRun.objects.get(pk=jobrunlog_entry_json.run.pk)
+    assert jobrun_json.log is not None
+    jobrun_json.delete_logs()
+    jobrun_json.refresh_from_db()
+    with pytest.raises(ObjectDoesNotExist):
+        jobrun_json.log

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 from pytest_factoryboy import register
 
+from batchrun.models import Command, Job, JobRun, JobRunLog
 from forms.models import Answer, Choice, Entry, Field, Form, Section
 from forms.models.form import EntrySection
 from forms.tests.conftest import fake
@@ -125,6 +126,39 @@ def area_search_test_data(
     )
 
     return area_search
+
+
+# Batchrun model factories
+@register
+class CommandFactory(factory.django.DjangoModelFactory):
+    type = "django-manage"
+
+    class Meta:
+        model = Command
+
+
+@register
+class JobFactory(factory.django.DjangoModelFactory):
+    command = factory.SubFactory(CommandFactory)
+
+    class Meta:
+        model = Job
+
+
+@register
+class JobRunFactory(factory.django.DjangoModelFactory):
+    job = factory.SubFactory(JobFactory)
+
+    class Meta:
+        model = JobRun
+
+
+@register
+class JobRunLogFactory(factory.django.DjangoModelFactory):
+    run = factory.SubFactory(JobRunFactory)
+
+    class Meta:
+        model = JobRunLog
 
 
 @register


### PR DESCRIPTION
Batchrun.JobRunLog has a field that uses TextJSONField. It was previously JSONField but a custom field was created later on. Just accessing the field crashed to a TypeError, the value coming out from the field was actually dict already and not a str.