### PR TITLE
add rent amount for contact to contact rents report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ leasing/management/commands/find_identifiers_for_lease_areas.py
 leasing/management/commands/joo.py
 leasing/management/commands/joo2.py
 leasing/management/commands/prefetch_test.py
+coverage.xml

--- a/leasing/report/lease/contact_rents.py
+++ b/leasing/report/lease/contact_rents.py
@@ -47,6 +47,12 @@ class ContactRentsReport(ReportBase):
             "format": "money",
             "width": 13,
         },
+        "rent_amount_for_contact": {
+            "label": _("Rent amount for contact"),
+            "source": "_report__tenants_rent_for_period",
+            "format": "money",
+            "width": 13,
+        },
     }
 
     def get_data(self, input_data):
@@ -57,8 +63,12 @@ class ContactRentsReport(ReportBase):
 
         leases = (
             Lease.objects.filter(
-                Q(end_date__isnull=True) | Q(end_date__gte=input_data["start_date"]),
                 tenants__contacts=contact,
+                tenants__deleted__isnull=True,
+                tenants__contacts__deleted__isnull=True,
+            )
+            .filter(
+                Q(end_date__isnull=True) | Q(end_date__gte=input_data["start_date"]),
             )
             .select_related(
                 "identifier",
@@ -74,13 +84,33 @@ class ContactRentsReport(ReportBase):
         )
 
         for lease in leases:
-            rent_for_period = lease.calculate_rent_amount_for_period(
-                input_data["start_date"], input_data["end_date"]
+            date_range = (
+                input_data["start_date"],
+                input_data["end_date"],
             )
-            lease._report__rent_for_period = (
-                rent_for_period.get_total_amount().quantize(
-                    Decimal(".01"), rounding=ROUND_HALF_UP
+            rent_for_period = lease.calculate_rent_amount_for_period(*date_range)
+            rent_total_amount_for_period = rent_for_period.get_total_amount()
+            lease._report__rent_for_period = rent_total_amount_for_period.quantize(
+                Decimal(".01"), rounding=ROUND_HALF_UP
+            )
+
+            tenant_shares = lease.get_tenant_shares_for_period(*date_range)
+            contacts_tenant = tenant_shares.get(contact)
+            if contacts_tenant is not None:
+                # One tenant can have multiple contacts, one tenant has only one rent share
+                rent_share = next(iter(contacts_tenant.keys()))
+                tenant_rent_share_portion = Decimal(
+                    rent_share.share_numerator / rent_share.share_denominator
                 )
-            )
+                rent_of_single_tenant_for_period = (
+                    rent_total_amount_for_period * tenant_rent_share_portion
+                )
+                lease._report__tenants_rent_for_period = (
+                    rent_of_single_tenant_for_period.quantize(
+                        Decimal(".01"), rounding=ROUND_HALF_UP
+                    )
+                )
+            else:
+                lease._report__tenants_rent_for_period = lease._report__rent_for_period
 
         return leases

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-21 13:09+0300\n"
+"POT-Creation-Date: 2024-08-26 14:25+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: fi\n"
@@ -3082,6 +3082,9 @@ msgstr "Vuokralaiset"
 
 msgid "Rent amount"
 msgstr "Vuokran määrä"
+
+msgid "Rent amount for contact"
+msgstr "Asiakkaan vuokran määrä"
 
 msgid "Contact not found"
 msgstr "Asiakasta ei löytynyt"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-21 13:09+0300\n"
+"POT-Creation-Date: 2024-08-26 14:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3084,6 +3084,9 @@ msgstr "Arrendatorer"
 
 msgid "Rent amount"
 msgstr "Arrendets belopp"
+
+msgid "Rent amount for contact"
+msgstr ""
 
 msgid "Contact not found"
 msgstr "Klienten hittades inte"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -3086,7 +3086,7 @@ msgid "Rent amount"
 msgstr "Arrendets belopp"
 
 msgid "Rent amount for contact"
-msgstr ""
+msgstr "Kundens hyra"
 
 msgid "Contact not found"
 msgstr "Klienten hittades inte"


### PR DESCRIPTION
The issue was that there can be multiple contacts/tenants appearing on the report for a specific contact, but one couldn't see the share of rent this one contact has when the rent is shared between multiple parties.
This adds a new column to the report which includes the share of the specified contact.

utilizes function get_tenant_shares_for_period to get tenant shares for the chosen period, then uses those tenant shares to calculate rent for individual contact. 