### PR TITLE
Form field and intended use django admin filters

### DIFF
--- a/forms/admin.py
+++ b/forms/admin.py
@@ -25,6 +25,9 @@ class FormChoiceField(forms.ModelChoiceField):
 
 
 class FieldModelAdmin(admin.ModelAdmin):
+    search_fields = [
+        "label_fi",
+    ]
     list_display = (
         "label",
         "section",

--- a/leasing/admin.py
+++ b/leasing/admin.py
@@ -769,6 +769,19 @@ class ServiceUnitGroupMappingAdmin(admin.ModelAdmin):
     pass
 
 
+class IntendedUseAdmin(admin.ModelAdmin):
+    list_display = (
+        "name",
+        "service_unit",
+    )
+    search_fields = ["name_fi"]
+    list_filter = ("service_unit",)
+    ordering = (
+        "name_fi",
+        "service_unit",
+    )
+
+
 admin.site.register(Area, AreaAdmin)
 admin.site.register(AreaSource, AreaSourceAdmin)
 admin.site.register(AreaNote, AreaNoteAdmin)
@@ -789,7 +802,7 @@ admin.site.register(InfillDevelopmentCompensation, InfillDevelopmentCompensation
 admin.site.register(
     InfillDevelopmentCompensationLease, InfillDevelopmentCompensationLeaseAdmin
 )
-admin.site.register(IntendedUse, NameAdmin)
+admin.site.register(IntendedUse, IntendedUseAdmin)
 admin.site.register(InterestRate, InterestRateAdmin)
 admin.site.register(Inspection, InspectionAdmin)
 admin.site.register(Invoice, InvoiceAdmin)


### PR DESCRIPTION
Adds the following features to Django admin:
 - search form fields by label
 - search intended uses by name, and filter them by service unit

I have used `label_fi` for fields and `name_fi` for intended uses, because the `name` and `label` fields do not work for the search fields.