### PR TITLE
Update KUVA intended uses

### DIFF
--- a/leasing/fixtures/intended_use.json
+++ b/leasing/fixtures/intended_use.json
@@ -2443,15 +2443,7 @@
     "model": "leasing.IntendedUse",
     "pk": 306,
     "fields": {
-      "name": "Maanvuokrasopimukset konttien/vajojen/majojen sijoittamiseen",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 307,
-    "fields": {
-      "name": "Metsästyssopimukset",
+      "name": "Maanvuokrasopimukset konttien/vajojen/majojen sijoittamiseen (LIPA)",
       "service_unit": 3
     }
   },
@@ -2459,7 +2451,7 @@
     "model": "leasing.IntendedUse",
     "pk": 308,
     "fields": {
-      "name": "Aluekeräyspisteet ja varhaisjakelun paikat",
+      "name": "Aluekeräyspisteet ja varhaisjakelun paikat (LIPA)",
       "service_unit": 3
     }
   },
@@ -2467,7 +2459,7 @@
     "model": "leasing.IntendedUse",
     "pk": 309,
     "fields": {
-      "name": "Liikuntapuistojen ja -kenttien maa-alueet",
+      "name": "Liikuntapuistojen ja -kenttien maa-alueet (LIPA)",
       "service_unit": 3
     }
   },
@@ -2475,7 +2467,7 @@
     "model": "leasing.IntendedUse",
     "pk": 310,
     "fields": {
-      "name": "Ylipainehallien maa-alueet",
+      "name": "Ylipainehallien maa-alueet (LIPA)",
       "service_unit": 3
     }
   },
@@ -2483,15 +2475,7 @@
     "model": "leasing.IntendedUse",
     "pk": 311,
     "fields": {
-      "name": "Liikuntahallien ym. maa-alueet ",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 312,
-    "fields": {
-      "name": "Golfkentät",
+      "name": "Liikuntahallien ym. maa-alueet (LIPA)",
       "service_unit": 3
     }
   },
@@ -2499,15 +2483,7 @@
     "model": "leasing.IntendedUse",
     "pk": 313,
     "fields": {
-      "name": "Pysäköintialueet",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 314,
-    "fields": {
-      "name": "Laidunalueet / hevosten jaloittelualueet",
+      "name": "Pysäköintialueet (LIPA)",
       "service_unit": 3
     }
   },
@@ -2515,7 +2491,7 @@
     "model": "leasing.IntendedUse",
     "pk": 315,
     "fields": {
-      "name": "Kioskipaikat",
+      "name": "Kioskipaikat (LIPA)",
       "service_unit": 3
     }
   },
@@ -2523,7 +2499,7 @@
     "model": "leasing.IntendedUse",
     "pk": 316,
     "fields": {
-      "name": "Terassialueet",
+      "name": "Terassialueet (LIPA)",
       "service_unit": 3
     }
   },
@@ -2531,7 +2507,7 @@
     "model": "leasing.IntendedUse",
     "pk": 317,
     "fields": {
-      "name": "Tukiasemat",
+      "name": "Tukiasemat (LIPA)",
       "service_unit": 3
     }
   },
@@ -2539,15 +2515,7 @@
     "model": "leasing.IntendedUse",
     "pk": 318,
     "fields": {
-      "name": "Työmaatukikohdat",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 319,
-    "fields": {
-      "name": "Tulipaikat (ulkoilualueilla)",
+      "name": "Työmaatukikohdat (LIPA)",
       "service_unit": 3
     }
   },
@@ -2555,15 +2523,7 @@
     "model": "leasing.IntendedUse",
     "pk": 320,
     "fields": {
-      "name": "Koiraurheilu ja agilitykentät",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 321,
-    "fields": {
-      "name": "VPK:n harjoitusalue",
+      "name": "Koiraurheilu ja agilitykentät (LIPA)",
       "service_unit": 3
     }
   },
@@ -2571,7 +2531,7 @@
     "model": "leasing.IntendedUse",
     "pk": 322,
     "fields": {
-      "name": "Ammunta-/jousiammuntaradat",
+      "name": "Ammunta-/jousiammuntaradat (LIPA)",
       "service_unit": 3
     }
   },
@@ -2579,47 +2539,7 @@
     "model": "leasing.IntendedUse",
     "pk": 323,
     "fields": {
-      "name": "Seikkailupuistot",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 324,
-    "fields": {
-      "name": "Ravirata",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 325,
-    "fields": {
-      "name": "Venesatamat",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 326,
-    "fields": {
-      "name": "Laiturinpito-oikeudet",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 327,
-    "fields": {
-      "name": "Aluspaikat",
-      "service_unit": 3
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 328,
-    "fields": {
-      "name": "Telakka-alueet",
+      "name": "Seikkailupuistot (LIPA)",
       "service_unit": 3
     }
   },
@@ -2627,7 +2547,7 @@
     "model": "leasing.IntendedUse",
     "pk": 329,
     "fields": {
-      "name": "Maanvuokrasopimukset konttien/vajojen/majojen sijoittamiseen",
+      "name": "Maanvuokrasopimukset konttien/vajojen/majojen sijoittamiseen (UPA)",
       "service_unit": 4
     }
   },
@@ -2635,7 +2555,7 @@
     "model": "leasing.IntendedUse",
     "pk": 330,
     "fields": {
-      "name": "Metsästyssopimukset",
+      "name": "Metsästyssopimukset (UPA)",
       "service_unit": 4
     }
   },
@@ -2643,7 +2563,7 @@
     "model": "leasing.IntendedUse",
     "pk": 331,
     "fields": {
-      "name": "Aluekeräyspisteet ja varhaisjakelun paikat",
+      "name": "Aluekeräyspisteet ja varhaisjakelun paikat (UPA)",
       "service_unit": 4
     }
   },
@@ -2651,7 +2571,7 @@
     "model": "leasing.IntendedUse",
     "pk": 332,
     "fields": {
-      "name": "Liikuntapuistojen ja -kenttien maa-alueet",
+      "name": "Liikuntapuistojen ja -kenttien maa-alueet (UPA)",
       "service_unit": 4
     }
   },
@@ -2659,7 +2579,7 @@
     "model": "leasing.IntendedUse",
     "pk": 333,
     "fields": {
-      "name": "Ylipainehallien maa-alueet",
+      "name": "Ylipainehallien maa-alueet (UPA)",
       "service_unit": 4
     }
   },
@@ -2667,7 +2587,7 @@
     "model": "leasing.IntendedUse",
     "pk": 334,
     "fields": {
-      "name": "Liikuntahallien ym. maa-alueet ",
+      "name": "Liikuntahallien ym. maa-alueet (UPA)",
       "service_unit": 4
     }
   },
@@ -2675,7 +2595,7 @@
     "model": "leasing.IntendedUse",
     "pk": 335,
     "fields": {
-      "name": "Golfkentät",
+      "name": "Golfkentät (UPA)",
       "service_unit": 4
     }
   },
@@ -2683,7 +2603,7 @@
     "model": "leasing.IntendedUse",
     "pk": 336,
     "fields": {
-      "name": "Pysäköintialueet",
+      "name": "Pysäköintialueet (UPA)",
       "service_unit": 4
     }
   },
@@ -2691,7 +2611,7 @@
     "model": "leasing.IntendedUse",
     "pk": 337,
     "fields": {
-      "name": "Laidunalueet / hevosten jaloittelualueet",
+      "name": "Laidunalueet / hevosten jaloittelualueet (UPA)",
       "service_unit": 4
     }
   },
@@ -2699,7 +2619,7 @@
     "model": "leasing.IntendedUse",
     "pk": 338,
     "fields": {
-      "name": "Kioskipaikat",
+      "name": "Kioskipaikat (UPA)",
       "service_unit": 4
     }
   },
@@ -2707,7 +2627,7 @@
     "model": "leasing.IntendedUse",
     "pk": 339,
     "fields": {
-      "name": "Terassialueet",
+      "name": "Terassialueet (UPA)",
       "service_unit": 4
     }
   },
@@ -2715,7 +2635,7 @@
     "model": "leasing.IntendedUse",
     "pk": 340,
     "fields": {
-      "name": "Tukiasemat",
+      "name": "Tukiasemat (UPA)",
       "service_unit": 4
     }
   },
@@ -2723,7 +2643,7 @@
     "model": "leasing.IntendedUse",
     "pk": 341,
     "fields": {
-      "name": "Työmaatukikohdat",
+      "name": "Työmaatukikohdat (UPA)",
       "service_unit": 4
     }
   },
@@ -2731,7 +2651,7 @@
     "model": "leasing.IntendedUse",
     "pk": 342,
     "fields": {
-      "name": "Tulipaikat (ulkoilualueilla)",
+      "name": "Tulipaikat (ulkoilualueilla) (UPA)",
       "service_unit": 4
     }
   },
@@ -2739,15 +2659,7 @@
     "model": "leasing.IntendedUse",
     "pk": 343,
     "fields": {
-      "name": "Koiraurheilu ja agilitykentät",
-      "service_unit": 4
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 344,
-    "fields": {
-      "name": "VPK:n harjoitusalue",
+      "name": "Koiraurheilu ja agilitykentät (UPA)",
       "service_unit": 4
     }
   },
@@ -2755,7 +2667,7 @@
     "model": "leasing.IntendedUse",
     "pk": 345,
     "fields": {
-      "name": "Ammunta-/jousiammuntaradat",
+      "name": "Ammunta-/jousiammuntaradat (UPA)",
       "service_unit": 4
     }
   },
@@ -2763,7 +2675,7 @@
     "model": "leasing.IntendedUse",
     "pk": 346,
     "fields": {
-      "name": "Seikkailupuistot",
+      "name": "Seikkailupuistot (UPA)",
       "service_unit": 4
     }
   },
@@ -2811,15 +2723,7 @@
     "model": "leasing.IntendedUse",
     "pk": 352,
     "fields": {
-      "name": "Maanvuokrasopimukset konttien/vajojen/majojen sijoittamiseen",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 353,
-    "fields": {
-      "name": "Metsästyssopimukset",
+      "name": "Maanvuokrasopimukset konttien/vajojen/majojen sijoittamiseen (NUP)",
       "service_unit": 5
     }
   },
@@ -2827,39 +2731,7 @@
     "model": "leasing.IntendedUse",
     "pk": 354,
     "fields": {
-      "name": "Aluekeräyspisteet ja varhaisjakelun paikat",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 355,
-    "fields": {
-      "name": "Liikuntapuistojen ja -kenttien maa-alueet",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 356,
-    "fields": {
-      "name": "Ylipainehallien maa-alueet",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 357,
-    "fields": {
-      "name": "Liikuntahallien ym. maa-alueet ",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 358,
-    "fields": {
-      "name": "Golfkentät",
+      "name": "Aluekeräyspisteet ja varhaisjakelun paikat (NUP)",
       "service_unit": 5
     }
   },
@@ -2867,15 +2739,7 @@
     "model": "leasing.IntendedUse",
     "pk": 359,
     "fields": {
-      "name": "Pysäköintialueet",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 360,
-    "fields": {
-      "name": "Laidunalueet / hevosten jaloittelualueet",
+      "name": "Pysäköintialueet (NUP)",
       "service_unit": 5
     }
   },
@@ -2883,15 +2747,7 @@
     "model": "leasing.IntendedUse",
     "pk": 361,
     "fields": {
-      "name": "Kioskipaikat",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 362,
-    "fields": {
-      "name": "Terassialueet",
+      "name": "Kioskipaikat (NUP)",
       "service_unit": 5
     }
   },
@@ -2899,7 +2755,7 @@
     "model": "leasing.IntendedUse",
     "pk": 363,
     "fields": {
-      "name": "Tukiasemat",
+      "name": "Tukiasemat (NUP)",
       "service_unit": 5
     }
   },
@@ -2907,87 +2763,7 @@
     "model": "leasing.IntendedUse",
     "pk": 364,
     "fields": {
-      "name": "Työmaatukikohdat",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 365,
-    "fields": {
-      "name": "Tulipaikat (ulkoilualueilla)",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 366,
-    "fields": {
-      "name": "Koiraurheilu ja agilitykentät",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 367,
-    "fields": {
-      "name": "VPK:n harjoitusalue",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 368,
-    "fields": {
-      "name": "Ammunta-/jousiammuntaradat",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 369,
-    "fields": {
-      "name": "Seikkailupuistot",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 370,
-    "fields": {
-      "name": "Ravirata",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 371,
-    "fields": {
-      "name": "Venesatamat",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 372,
-    "fields": {
-      "name": "Laiturinpito-oikeudet",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 373,
-    "fields": {
-      "name": "Aluspaikat",
-      "service_unit": 5
-    }
-  },
-  {
-    "model": "leasing.IntendedUse",
-    "pk": 374,
-    "fields": {
-      "name": "Telakka-alueet",
+      "name": "Työmaatukikohdat (NUP)",
       "service_unit": 5
     }
   }


### PR DESCRIPTION
Intended uses list in advanced search shows intended uses from all three KUVA service units that appear as not distinct from one another. This change removes intended uses from some service units they are not needed in, and adds the abbreviation of the service unit name for intended uses that belong to several KUVA service units.

![image](https://github.com/user-attachments/assets/330e8110-2757-4227-b853-1a15b50ca50c)
