### PR TITLE
Group model permissions: areasearchintendeduse

### DIFF
--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -468,6 +468,15 @@ DEFAULT_MODEL_PERMS = {
         6: ("view",),
         7: ("view", "add", "change", "delete"),
     },
+    "areasearchintendeduse": {
+        1: ("view",),
+        2: ("view",),
+        3: ("view",),
+        4: ("view",),
+        5: ("view",),
+        6: ("view",),
+        7: ("view", "add", "change", "delete"),
+    },
     "intendeduse": {
         1: ("view",),
         2: ("view",),

--- a/leasing/migrations/0074_delete_duplicate_intended_use_permissions.py
+++ b/leasing/migrations/0074_delete_duplicate_intended_use_permissions.py
@@ -7,10 +7,26 @@ def remove_duplicate_intended_use_permissions(apps, schema_editor):
     """
     Remove duplicate intended use permissions and the related auth group permissions.
     """
-    Permission = apps.get_model("auth", "Permission")
-    permissions = Permission.objects.filter(
-        name__contains="Area search intended use",
-        codename__contains="_intendeduse",
+    permission = apps.get_model("auth", "Permission")
+
+    permission.objects.filter(
+        name="Can view Area search intended use",
+        codename="view_intendeduse",
+    ).delete()
+
+    permission.objects.filter(
+        name="Can add Area search intended use",
+        codename="add_intendeduse",
+    ).delete()
+
+    permission.objects.filter(
+        name="Can change Area search intended use",
+        codename="change_intendeduse",
+    ).delete()
+
+    permission.objects.filter(
+        name="Can delete Area search intended use",
+        codename="delete_intendeduse",
     ).delete()
 
 

--- a/leasing/migrations/0074_delete_duplicate_intended_use_permissions.py
+++ b/leasing/migrations/0074_delete_duplicate_intended_use_permissions.py
@@ -1,0 +1,27 @@
+# Manually created
+
+from django.db import migrations
+
+
+def remove_duplicate_intended_use_permissions(apps, schema_editor):
+    """
+    Remove duplicate intended use permissions and the related auth group permissions.
+    """
+    Permission = apps.get_model("auth", "Permission")
+    permissions = Permission.objects.filter(
+        name__contains="Area search intended use",
+        codename__contains="_intendeduse",
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("leasing", "0073_intendeduse_service_unit"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=remove_duplicate_intended_use_permissions,
+        ),
+    ]


### PR DESCRIPTION
Previously, permissions related to intended uses and area search intended uses had the same codenames, but different names, and they created a conflict in my local environment for an unknown reason. The area search intended uses are not defined as separate entities in the code, but somehow connected to intended uses. 

This change explicitly defines permissions for area search intended uses separately from intended uses, to make the logic clearer.