### PR TITLE
Paikkatietovipunen vuokraalueet view: add tyypin tunnus and simplify vuokraustunnus

### DIFF
--- a/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.py
+++ b/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.py
@@ -16,10 +16,10 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            sql_file=load_sql_file(
+            sql=load_sql_file(
                 "./0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.sql"
             ),
-            reverse_sql_file=load_sql_file(
+            reverse_sql=load_sql_file(
                 "./0060_fix_paikkatietovipunen_vuokraalueet_remove_intended_use_requirement.sql"
             ),
         ),

--- a/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.py
+++ b/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.py
@@ -3,39 +3,10 @@ from pathlib import Path
 from django.db import migrations
 
 
-class RunSQLFromFile(migrations.RunSQL):
-    def __init__(self, sql_file, reverse_sql_file=None, **kwargs):
-        super().__init__(sql="", **kwargs)
-        self.sql_file = sql_file
-        self.reverse_sql_file = reverse_sql_file
-        self._sql = "unread"
-        self._reverse_sql = "unread"
-
-    @property
-    def sql(self):
-        if self._sql == "unread":
-            self._sql = self._read_file(self.sql_file)
-        return self._sql
-
-    @sql.setter
-    def sql(self, value):
-        pass
-
-    @property
-    def reverse_sql(self):
-        if self._reverse_sql == "unread":
-            self._reverse_sql = self._read_file(self.reverse_sql_file)
-        return self._reverse_sql
-
-    @reverse_sql.setter
-    def reverse_sql(self, value):
-        pass
-
-    def _read_file(self, filename):
-        if filename is None:
-            return None
-        with open(Path(__file__).parent / filename, encoding="utf8") as fp:
-            return fp.read()
+def load_sql_file(name):
+    file_path = Path(__file__).resolve().parent / name
+    with open(file_path, encoding="utf-8") as file:
+        return file.read()
 
 
 class Migration(migrations.Migration):
@@ -44,8 +15,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        RunSQLFromFile(
-            sql_file="./0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.sql",
-            reverse_sql_file="./0060_fix_paikkatietovipunen_vuokraalueet_remove_intended_use_requirement.sql",
+        migrations.RunSQL(
+            sql_file=load_sql_file(
+                "./0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.sql"
+            ),
+            reverse_sql_file=load_sql_file(
+                "./0060_fix_paikkatietovipunen_vuokraalueet_remove_intended_use_requirement.sql"
+            ),
         ),
     ]

--- a/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.py
+++ b/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from django.db import migrations
+
+
+class RunSQLFromFile(migrations.RunSQL):
+    def __init__(self, sql_file, reverse_sql_file=None, **kwargs):
+        super().__init__(sql="", **kwargs)
+        self.sql_file = sql_file
+        self.reverse_sql_file = reverse_sql_file
+        self._sql = "unread"
+        self._reverse_sql = "unread"
+
+    @property
+    def sql(self):
+        if self._sql == "unread":
+            self._sql = self._read_file(self.sql_file)
+        return self._sql
+
+    @sql.setter
+    def sql(self, value):
+        pass
+
+    @property
+    def reverse_sql(self):
+        if self._reverse_sql == "unread":
+            self._reverse_sql = self._read_file(self.reverse_sql_file)
+        return self._reverse_sql
+
+    @reverse_sql.setter
+    def reverse_sql(self, value):
+        pass
+
+    def _read_file(self, filename):
+        if filename is None:
+            return None
+        with open(Path(__file__).parent / filename, encoding="utf8") as fp:
+            return fp.read()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("leasing", "0075_olddwellingsinhousingcompaniespriceindex_and_more"),
+    ]
+
+    operations = [
+        RunSQLFromFile(
+            sql_file="./0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.sql",
+            reverse_sql_file="./0060_fix_paikkatietovipunen_vuokraalueet_remove_intended_use_requirement.sql",
+        ),
+    ]

--- a/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.sql
+++ b/leasing/migrations/0076_paikkatietovipunen_vuokraalueet_view_vuokraustunnus_and_tyypin_tunnus.sql
@@ -5,11 +5,8 @@ CREATE OR REPLACE VIEW public.paikkatietovipunen_vuokraalueet
  AS
  SELECT lease.id AS vuokraus_id,
     l_area.identifier AS kiinteistotunnus,
-    concat(ltype.identifier, ( SELECT leasing_municipality.identifier
-           FROM leasing_municipality
-          WHERE leasing_municipality.id = lid.municipality_id), ( SELECT lpad(leasing_district.identifier::text, 2, '0'::text) AS lpad
-           FROM leasing_district
-          WHERE leasing_district.id = lid.district_id), '-', lid.sequence) AS vuokraustunnus,
+    ltype.identifier AS tyypin_tunnus,
+    lid.identifier AS vuokraustunnus,
     ( SELECT leasing_contract.contract_number
            FROM leasing_contract
           WHERE leasing_contract.lease_id = lease.id


### PR DESCRIPTION
Add the requested tyypin tunnus (lease type identifier, such as "A1", "Y9" etc).

Remove the outdated concatenation to generate lease identifier on the fly.

Uncomment `DROP VIEW public.paikkatietovipunen_vuokraalueet;` to make the migrations work with changing column names and data types. Without that, these changes would not be allowed for some reason.