### PR TITLE
enable helusers user migration

### DIFF
--- a/mvj/settings.py
+++ b/mvj/settings.py
@@ -309,6 +309,13 @@ NLS_IMPORT_ROOT = project_root("nls_leasehold_transfers")
 
 # Enable `{/v1}/pub/helauth/logout/oidc/backchannel/` endpoint
 HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = True
+# Migrate Tunnistamo users to Keycloak users, replaces old uuid with new based on email.
+# Migration is triggered on login.
+HELUSERS_USER_MIGRATE_ENABLED = True
+# List of email domains to migrate.
+HELUSERS_USER_MIGRATE_EMAIL_DOMAINS = ["hel.fi"]
+# List of authentication methods to migrate.
+HELUSERS_USER_MIGRATE_AMRS = ["helsinkiad"]
 
 OIDC_API_TOKEN_AUTH = {
     "AUDIENCE": env.str("TOKEN_AUTH_ACCEPTED_AUDIENCE"),


### PR DESCRIPTION
configured for hel.fi domain and helsinkiad

Documentation for the feature: https://github.com/City-of-Helsinki/django-helusers?tab=readme-ov-file#migrating-old-user-from-tunnistamo-to-keycloak