### PR TITLE
MVJ-395 bases of rents in statistic report I

### DIFF
--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -54,7 +54,11 @@ def get_matti_report(obj):
 def get_permitted_building_volume_residential(obj):
     volumes = defaultdict(Decimal)
     for basis_of_rent in obj.basis_of_rents.all():
-        if basis_of_rent.intended_use_id not in RESIDENTIAL_INTENDED_USE_IDS:
+        if (
+            basis_of_rent.intended_use_id not in RESIDENTIAL_INTENDED_USE_IDS
+            or basis_of_rent.archived_at
+            or not basis_of_rent.locked_at
+        ):
             continue
 
         volumes[basis_of_rent.area_unit] += basis_of_rent.area

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -76,7 +76,11 @@ def get_permitted_building_volume_residential(obj):
 def get_permitted_building_volume_business(obj):
     volumes = defaultdict(Decimal)
     for basis_of_rent in obj.basis_of_rents.all():
-        if basis_of_rent.intended_use_id in RESIDENTIAL_INTENDED_USE_IDS:
+        if (
+            basis_of_rent.intended_use_id in RESIDENTIAL_INTENDED_USE_IDS
+            or basis_of_rent.archived_at
+            or not basis_of_rent.locked_at
+        ):
             continue
 
         volumes[basis_of_rent.area_unit] += basis_of_rent.area
@@ -94,6 +98,9 @@ def get_permitted_building_volume_business(obj):
 def get_permitted_building_volume_total(obj):
     volumes = defaultdict(Decimal)
     for basis_of_rent in obj.basis_of_rents.all():
+        if basis_of_rent.archived_at or not basis_of_rent.locked_at:
+            continue
+
         volumes[basis_of_rent.area_unit] += basis_of_rent.area
 
     return " / ".join(
@@ -150,6 +157,8 @@ def get_average_amount_per_area_residential(obj):
         if (
             basis_of_rent.intended_use_id not in RESIDENTIAL_INTENDED_USE_IDS
             or not basis_of_rent.amount_per_area
+            or basis_of_rent.archived_at
+            or not basis_of_rent.locked_at
         ):
             continue
 
@@ -176,6 +185,8 @@ def get_average_amount_per_area_business(obj):
         if (
             basis_of_rent.intended_use_id in RESIDENTIAL_INTENDED_USE_IDS
             or not basis_of_rent.amount_per_area
+            or basis_of_rent.archived_at
+            or not basis_of_rent.locked_at
         ):
             continue
 


### PR DESCRIPTION
The following fields need to exclude the data of archived and not-locked bases of rents:

- Rakennus-oikeus (asuminen)
- Rakennusoikeus (yritystila)
- Kokonaisrakennusoikeus
- €/k-m2 Asuminen
- €/k-m2 Yritystila