### PR TITLE
set cache key before update in apitoken auth

### DIFF
--- a/users/oidc.py
+++ b/users/oidc.py
@@ -1,21 +1,29 @@
 from django.core.cache import cache
+from django.db import DatabaseError, IntegrityError
+from helusers.authz import UserAuthorization
 from helusers.oidc import ApiTokenAuthentication
+
+from users.models import User
 
 
 class MvjApiTokenAuthentication(ApiTokenAuthentication):
     def authenticate(self, request):
-        result = super().authenticate(request)
+        result: tuple[User | None, UserAuthorization] = super().authenticate(request)
 
         if not result:
             return
 
         user, auth = result
-
         # Update users service units every 10 minutes
         if user and user.id:
             cache_key = f"service_units_updated_user_{user.id}"
-            if not cache.get(cache_key):
-                user.update_service_units()
+            cache_value = cache.get(cache_key)
+            if not cache_value:
+                # Set cache before `update_service_units()` to prevent multiple updates
                 cache.set(cache_key, True, timeout=600)  # 10 minutes
+                try:
+                    user.update_service_units()
+                except (IntegrityError, DatabaseError):
+                    cache.delete(cache_key)
 
         return user, auth


### PR DESCRIPTION
this attempts to reduce the amount of deadlocks happening upon login by adding the cache key before updating, with the intention being that it would prevent multiple updates running simultaneously.

This might not fix the underlying issue, but should help avoid at least multiple atomic transactions by running `user.update_service_units()` multiple times.