### PR TITLE
make reports use calculate_rent_amount_for_year() with dry_run=True

### DIFF
--- a/leasing/calculation/result.py
+++ b/leasing/calculation/result.py
@@ -20,7 +20,7 @@ class CalculationAmount:
         self.amount = amount
         self.date_range_start = date_range_start
         self.date_range_end = date_range_end
-        self.sub_amounts = []
+        self.sub_amounts: list[CalculationAmount] = []
         self.notes = []
 
     def __str__(self):
@@ -107,7 +107,7 @@ class CalculationResult:
     def __init__(self, date_range_start, date_range_end):
         self.date_range_start = date_range_start
         self.date_range_end = date_range_end
-        self.amounts = []
+        self.amounts: list[CalculationAmount] = []
 
     def __str__(self):
         result = "Date range: {} - {}\n".format(

--- a/leasing/models/lease.py
+++ b/leasing/models/lease.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import connection, models, transaction
-from django.db.models import Max, Q
+from django.db.models import Max, Q, QuerySet
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from enumfields import EnumField
@@ -35,6 +35,7 @@ from leasing.models.mixins import (
     TimeStampedModel,
     TimeStampedSafeDeleteModel,
 )
+from leasing.models.rent import Rent
 from leasing.models.utils import (
     fix_amount_for_overlap,
     get_range_overlap_and_remainder,
@@ -865,7 +866,9 @@ class Lease(TimeStampedSafeDeleteModel):
 
         return result
 
-    def get_active_rents_on_period(self, date_range_start, date_range_end):
+    def get_active_rents_on_period(
+        self, date_range_start, date_range_end
+    ) -> QuerySet[Rent]:
         rent_range_filter = Q(
             Q(Q(end_date=None) | Q(end_date__gte=date_range_start))
             & Q(Q(start_date=None) | Q(start_date__lte=date_range_end))

--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -1223,7 +1223,9 @@ class RentAdjustment(TimeStampedSafeDeleteModel):
                 adjustment = min(adjustment_left, rent_amount)
 
             if update_amount_total:
-                self.amount_left = max(0, adjustment_left - adjustment)
+                self.amount_left = Decimal(
+                    max(0, adjustment_left - adjustment)
+                ).quantize(Decimal("0.00"), rounding=ROUND_HALF_UP)
                 self.save()
         else:
             raise NotImplementedError(

--- a/leasing/models/utils.py
+++ b/leasing/models/utils.py
@@ -3,11 +3,16 @@ import re
 from collections import OrderedDict, namedtuple
 from datetime import date
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Manager, Model
 
 from leasing.enums import PeriodType
+
+if TYPE_CHECKING:
+    # Avoid circular import
+    from leasing.models.rent import RentAdjustment
 
 
 def get_range_overlap(start1, end1, start2, end2):
@@ -88,7 +93,7 @@ def get_date_range_amount_from_monthly_amount(
     return total
 
 
-def fix_amount_for_overlap(amount, overlap, remainders):
+def fix_amount_for_overlap(amount, overlap: tuple[date, date], remainders):
     if not remainders or not amount:
         return amount
 
@@ -314,7 +319,9 @@ def _get_date_range_from_item(item, fill_min_max_values=True):
     return start_date, end_date
 
 
-def group_items_in_period_by_date_range(items, min_date, max_date):
+def group_items_in_period_by_date_range(
+    items: list["RentAdjustment"], min_date, max_date
+) -> dict[tuple[date, date], list["RentAdjustment"]]:
     grouped_items = {}
 
     if not items:

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -115,7 +115,7 @@ def get_permitted_building_volume_total(obj):
 
 @lru_cache(maxsize=1)
 def _get_rent_amount_for_year(obj, year):
-    return obj.calculate_rent_amount_for_year(year)
+    return obj.calculate_rent_amount_for_year(year, dry_run=True)
 
 
 def get_rent_amount_residential(obj):

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -114,8 +114,8 @@ def get_permitted_building_volume_total(obj):
 
 
 @lru_cache(maxsize=1)
-def _get_rent_amount_for_year(obj, year):
-    return obj.calculate_rent_amount_for_year(year, dry_run=True)
+def _get_rent_amount_for_year(lease: Lease, year):
+    return lease.calculate_rent_amount_for_year(year, dry_run=True)
 
 
 def get_rent_amount_residential(obj):

--- a/leasing/report/lease/rent_compare.py
+++ b/leasing/report/lease/rent_compare.py
@@ -124,7 +124,9 @@ class RentCompareReport(AsyncReportBase):
             for year in [first_year, second_year]:
                 year_key = "first_year" if year == first_year else "second_year"
                 try:
-                    rent_amount = lease.calculate_rent_amount_for_year(year)
+                    rent_amount = lease.calculate_rent_amount_for_year(
+                        year, dry_run=True
+                    )
 
                     result[year_key] = rent_amount.get_total_amount()
                 except NotImplementedError:

--- a/leasing/report/lease/rent_forecast.py
+++ b/leasing/report/lease/rent_forecast.py
@@ -95,7 +95,9 @@ class RentForecastReport(AsyncReportBase):
 
             for year in years:
                 try:
-                    rent_amount = lease.calculate_rent_amount_for_year(year)
+                    rent_amount = lease.calculate_rent_amount_for_year(
+                        year, dry_run=True
+                    )
 
                     rent_sums_key = "external"
                     if lease.type.identifier in INTERNAL_LEASE_TYPES:


### PR DESCRIPTION
Calling the function without dry_run=True causes a side effect that causes unnecessary updates to RentAdjustment objects in case the value is 0, it is updated to 0.00.