### PR TITLE
area import: update external_id only for plan units

### DIFF
--- a/leasing/importer/area.py
+++ b/leasing/importer/area.py
@@ -413,7 +413,6 @@ class AreaImporter(BaseImporter):
     def get_update_data(
         self,
         row: NamedTupleUnknown,
-        area_import: AreaImport,
         metadata: Metadata,
         geom: geos.MultiPolygon,
     ):
@@ -422,8 +421,10 @@ class AreaImporter(BaseImporter):
             "metadata": metadata,
         }
 
-        if area_import["area_type"] == AreaType.PLAN_UNIT:
-            update_data["external_id"] = row.id if row.id else None
+        ext_id = getattr(row, "id", None)
+
+        if ext_id:
+            update_data["external_id"] = ext_id
 
         return update_data
 
@@ -551,9 +552,7 @@ class AreaImporter(BaseImporter):
             if geom is None:
                 continue
 
-            update_data: UpdateData = self.get_update_data(
-                row, area_import, metadata, geom
-            )
+            update_data: UpdateData = self.get_update_data(row, metadata, geom)
 
             imported_identifiers, error_count = self.update_or_create_areas(
                 areas, update_data, match_data, imported_identifiers, error_count

--- a/leasing/importer/area.py
+++ b/leasing/importer/area.py
@@ -423,7 +423,7 @@ class AreaImporter(BaseImporter):
 
         ext_id = getattr(row, "id", None)
 
-        if ext_id:
+        if ext_id is not None:
             update_data["external_id"] = ext_id
 
         return update_data


### PR DESCRIPTION
The area import script failed because it did not find id in the data rows of the SQL query result for `pre_detailed_plan`s. I think the best idea is to include the external_id only for `plan_unit`s for now. I am not aware of the other data sources.

```code
Updated area count 4632. Execution time: 16.71s (Row time avg: 0.00s, min: 0.00s, max: 0.03s)
Starting to remove stales...
Removed stale count 0. Execution time: 0.69s
The area import of type "detailed_plan" is completed. Execution time: 17.86s
Starting to import the area type "pre_detailed_plan"...
Maka: Hankerajaus
Starting to update areas...
Traceback (most recent call last):
  File "/home/mvj-api-stage/mvj-api-stage/manage.py", line 30, in <module>
    execute_from_command_line(sys.argv)
  File "/home/mvj-api-stage/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/home/mvj-api-stage/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/mvj-api-stage/venv/lib/python3.10/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/mvj-api-stage/venv/lib/python3.10/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/home/mvj-api-stage/mvj-api-stage/leasing/management/commands/mvj_import.py", line 42, in handle
    importer.execute()
  File "/home/mvj-api-stage/mvj-api-stage/leasing/importer/area.py", line 361, in execute
    self.process_area_import_type(area_import_type)
  File "/home/mvj-api-stage/mvj-api-stage/leasing/importer/area.py", line 596, in process_area_import_type
    imported_identifiers = self.process_rows(cursor, area_import, source, errors)
  File "/home/mvj-api-stage/mvj-api-stage/leasing/importer/area.py", line 540, in process_rows
    "external_id": row.id,
AttributeError: 'Row' object has no attribute 'id'
Sentry is attempting to send 2 pending events
Waiting up to 2 seconds
```