### PR TITLE
ReceivableType: increase pagination limit to 50

### DIFF
--- a/leasing/viewsets/invoice.py
+++ b/leasing/viewsets/invoice.py
@@ -33,7 +33,7 @@ from leasing.serializers.invoice import (
 )
 
 from ..permissions import IsMemberOfSameServiceUnit, MvjDjangoModelPermissions
-from .utils import AtomicTransactionModelViewSet
+from .utils import AtomicTransactionModelViewSet, ReceivableTypeResultSetPagination
 
 
 class InvoiceViewSet(FieldPermissionsViewsetMixin, AtomicTransactionModelViewSet):
@@ -169,3 +169,4 @@ class ReceivableTypeViewSet(ReadOnlyModelViewSet):
     queryset = ReceivableType.objects.all()
     serializer_class = ReceivableTypeSerializer
     filterset_class = ReceivableTypeFilter
+    pagination_class = ReceivableTypeResultSetPagination

--- a/leasing/viewsets/utils.py
+++ b/leasing/viewsets/utils.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
 from rest_framework import parsers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
@@ -111,3 +112,9 @@ def integrityerror_exception_handler(exc, context):
         )
 
     return response
+
+
+class ReceivableTypeResultSetPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = "page_size"
+    max_page_size = 50


### PR DESCRIPTION
The default limit for `GET receivable_type/` request is 30, but there are more receivable types for AKV than 30. The limit of response objects is increased to 50, so that all AKV receivable types could be shown.