### PR TITLE
Mvj 531 seasonal rent dates validation

### DIFF
--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -660,9 +660,8 @@ class Rent(TimeStampedSafeDeleteModel):
         if self.due_dates_type != DueDatesType.CUSTOM:
             return set()
 
-        return [
-            dd.as_daymonth() for dd in self.due_dates.all().order_by("month", "day")
-        ]
+        due_dates: QuerySet[RentDueDate] = self.due_dates
+        return [dd.as_daymonth() for dd in due_dates.all().order_by("month", "day")]
 
     def get_due_dates_as_daymonths(self):
         due_dates = []

--- a/leasing/serializers/rent.py
+++ b/leasing/serializers/rent.py
@@ -15,6 +15,7 @@ from leasing.models.rent import (
     ManagementSubventionFormOfManagement,
     TemporarySubvention,
 )
+from leasing.serializers.utils import validate_seasonal_day_for_month
 from users.serializers import UserSerializer
 
 from ..models import (
@@ -52,6 +53,10 @@ class RentDueDateSerializer(
     class Meta:
         model = RentDueDate
         fields = ("id", "day", "month")
+
+    def validate(self, data):
+        validate_seasonal_day_for_month(data.get("day"), data.get("month"))
+        return data
 
 
 class FixedInitialYearRentSerializer(
@@ -541,6 +546,10 @@ class RentCreateUpdateSerializer(
             raise serializers.ValidationError(
                 _("Due dates type must be custom if seasonal dates are set")
             )
+
+        start_day, start_month, end_day, end_month = seasonal_values
+        validate_seasonal_day_for_month(start_day, start_month)
+        validate_seasonal_day_for_month(end_day, end_month)
 
         return data
 

--- a/leasing/serializers/utils.py
+++ b/leasing/serializers/utils.py
@@ -312,8 +312,17 @@ def validate_seasonal_day_for_month(day: int | None, month: int | None):
     if day is None and month is None:
         return
 
-    if (day is None and month is not None) or (day is not None and month is None):
+    if day is None and month is not None:
         raise ValidationError({"day": _("Both day and month must be provided")})
+
+    if day is not None and month is None:
+        raise ValidationError({"month": _("Both day and month must be provided")})
+
+    if not isinstance(day, int):
+        raise ValidationError({"day": _("Day must be an integer")})
+
+    if not isinstance(month, int):
+        raise ValidationError({"month": _("Month must be an integer")})
 
     max_days_in_month = {
         1: 31,  # January
@@ -332,7 +341,9 @@ def validate_seasonal_day_for_month(day: int | None, month: int | None):
     }
 
     if month < 1 or month > 12:
-        raise ValidationError({"month": _(f"Invalid month: {month}")})
+        raise ValidationError(
+            {"month": _(f"Invalid month: {month}. Month must be between 1 and 12.")}
+        )
 
     max_day = max_days_in_month.get(month)
     if day < 1 or day > max_day:

--- a/leasing/serializers/utils.py
+++ b/leasing/serializers/utils.py
@@ -308,7 +308,13 @@ class FileSerializerMixin:
         return os.path.basename(obj.file.name)
 
 
-def validate_seasonal_day_for_month(day: int, month: int):
+def validate_seasonal_day_for_month(day: int | None, month: int | None):
+    if day is None and month is None:
+        return
+
+    if (day is None and month is not None) or (day is not None and month is None):
+        raise ValidationError({"day": _("Both day and month must be provided")})
+
     max_days_in_month = {
         1: 31,  # January
         # Since this a generic date and not a calendar date with year, accept only 28 days for February

--- a/leasing/serializers/utils.py
+++ b/leasing/serializers/utils.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import OneToOneRel
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -305,3 +306,28 @@ class FileSerializerMixin:
 
     def get_file_filename(self, obj):
         return os.path.basename(obj.file.name)
+
+
+def validate_seasonal_day_for_month(day: int, month: int):
+    max_days_in_month = {
+        1: 31,  # January
+        # Since this a generic date and not a calendar date with year, accept only 28 days for February
+        2: 28,  # February (non-leap year)
+        3: 31,  # March
+        4: 30,  # April
+        5: 31,  # May
+        6: 30,  # June
+        7: 31,  # July
+        8: 31,  # August
+        9: 30,  # September
+        10: 31,  # October
+        11: 30,  # November
+        12: 31,  # December
+    }
+
+    if month < 1 or month > 12:
+        raise ValidationError({"month": _(f"Invalid month: {month}")})
+
+    max_day = max_days_in_month.get(month)
+    if day < 1 or day > max_day:
+        raise ValidationError({"day": _(f"Invalid day: {day} for month: {month}")})

--- a/leasing/tests/serializers/test_utils.py
+++ b/leasing/tests/serializers/test_utils.py
@@ -1,0 +1,66 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from leasing.serializers.utils import validate_seasonal_day_for_month
+
+
+def test_validate_seasonal_day_for_month():
+    # Test valid cases
+    try:
+        validate_seasonal_day_for_month(1, 1)
+        validate_seasonal_day_for_month(28, 2)
+        validate_seasonal_day_for_month(30, 4)
+        validate_seasonal_day_for_month(31, 12)
+        validate_seasonal_day_for_month(None, None)  # No values to validate
+    except ValidationError:
+        pytest.fail("validate_seasonal_day_for_month() raised ValidationError!")
+
+    # Test month not within bounds
+    day, month = 1, 0
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert (
+        exc.value.detail.get("month")
+        == f"Invalid month: {month}. Month must be between 1 and 12."
+    )
+    day, month = 1, 13
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert (
+        exc.value.detail.get("month")
+        == f"Invalid month: {month}. Month must be between 1 and 12."
+    )
+
+    # Test day not within bounds
+    day, month = 0, 1
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert exc.value.detail.get("day") == f"Invalid day: {day} for month: {month}"
+
+    # Does not take leap years into account, as it is not a calendar day (with year)
+    day, month = 29, 2
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert exc.value.detail.get("day") == f"Invalid day: {day} for month: {month}"
+
+    # Test day and month provided
+    day, month = 1, None
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert exc.value.detail.get("month") == "Both day and month must be provided"
+
+    day, month = None, 1
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert exc.value.detail.get("day") == "Both day and month must be provided"
+
+    # Test invalid types
+    day, month = "2", 1
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert exc.value.detail.get("day") == "Day must be an integer"
+
+    day, month = 2, "1"
+    with pytest.raises(ValidationError) as exc:
+        validate_seasonal_day_for_month(day, month)
+    assert exc.value.detail.get("month") == "Month must be an integer"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MVJ 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-12 10:50+0300\n"
+"POT-Creation-Date: 2024-10-18 13:53+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: fi\n"
@@ -3465,6 +3465,23 @@ msgstr "Vuokrausperiaatetta tunnisteella {} ei löydy"
 
 msgid "Can't edit locked basis of rent item"
 msgstr "Lukittua vuokrausperiaatetta ei voi muokata"
+
+msgid "Both day and month must be provided"
+msgstr "Vaaditaan molemmat: päivä ja kuukausi"
+
+msgid "Day must be an integer"
+msgstr "Päivän pitää olla kokonaisluku"
+
+msgid "Month must be an integer"
+msgstr "Kuukauden pitää olla kokonaisluku"
+
+#, python-brace-format
+msgid "Invalid month: {month}. Month must be between 1 and 12."
+msgstr "Virheellinen kuukausi: {month}. Kuukauden pitää olla 1-12."
+
+#, python-brace-format
+msgid "Invalid day: {day} for month: {month}"
+msgstr "Vireellinen päivä: {day} kuukaudelle: {month}"
 
 msgid "Enter a valid business id."
 msgstr "Anna kelvollinen Y-tunnus."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-12 10:50+0300\n"
+"POT-Creation-Date: 2024-10-18 13:53+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3467,6 +3467,23 @@ msgstr "Arrenderingsprincipen med identifieraren {} hittas inte"
 
 msgid "Can't edit locked basis of rent item"
 msgstr "Låsta arrenderingsprinciper kan inte redigeras"
+
+msgid "Both day and month must be provided"
+msgstr ""
+
+msgid "Day must be an integer"
+msgstr ""
+
+msgid "Month must be an integer"
+msgstr ""
+
+#, python-brace-format
+msgid "Invalid month: {month}. Month must be between 1 and 12."
+msgstr ""
+
+#, python-brace-format
+msgid "Invalid day: {day} for month: {month}"
+msgstr ""
 
 msgid "Enter a valid business id."
 msgstr "Ange ett giltigt FO-nummer."


### PR DESCRIPTION
* Adds validation to `RentDueDateSerializer` for due dates
* Adds validation  to `RentCreateUpdateSerializer` for valid season start and end "dates"

This partly solves issues of MVJ-529, validation is only implemented at API level for Serializers. If MVJ-529 requires e.g. model level validation, it should be implemented separately. The logic would be almost the same, but the exception would come from django instead of django restframework