### PR TITLE
refactor invoicing gaps part of invoicing report, fixes memory issues

### DIFF
--- a/leasing/report/invoice/invoicing_review.py
+++ b/leasing/report/invoice/invoicing_review.py
@@ -467,7 +467,8 @@ WITH invoices_sorted AS (
         COALESCE(c.name, (c.first_name || ' ' || c.last_name)) AS recipient_name,
         COALESCE(r.start_date, l.start_date) AS rent_start_date,
         COALESCE(r.end_date, l.end_date) AS rent_end_date,
-        LEAD(i.billing_period_start_date) OVER (PARTITION BY r.id ORDER BY i.billing_period_start_date) AS next_start_date
+        LEAD(i.billing_period_start_date) OVER (PARTITION BY r.id ORDER BY i.billing_period_start_date)
+            AS next_start_date
     FROM
         leasing_invoice i
     INNER JOIN

--- a/leasing/report/invoice/invoicing_review.py
+++ b/leasing/report/invoice/invoicing_review.py
@@ -2,7 +2,6 @@ import datetime
 from collections import defaultdict
 from fractions import Fraction
 from io import BytesIO
-from itertools import groupby
 from operator import itemgetter
 
 import xlsxwriter
@@ -15,15 +14,14 @@ from enumfields.drf import EnumField
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from leasing.models import ReceivableType, ServiceUnit
+from leasing.models import ServiceUnit
 from leasing.report.excel import FormatType
 from leasing.report.lease.invoicing_disabled_report import INVOICING_DISABLED_REPORT_SQL
 from leasing.report.report_base import ReportBase
 from leasing.report.utils import (
-    BillingPeriodDataRow,
-    calculate_invoice_billing_period_days,
+    InvoicingGapsRow,
+    InvoicingReviewReportOutput,
     dictfetchall,
-    get_lease_period,
 )
 
 # Ids of receivable types that are not included in the gaps in the billing periods report
@@ -458,108 +456,122 @@ class InvoicingReviewReport(ReportBase):
         """
 
         query = """
-            SELECT li.identifier AS "lease_identifier",
-                l.id AS "lease_id",
-                l.start_date,
-                l.end_date,
-                r.id AS "rent_id",
-                r.start_date AS "rent_start_date",
-                r.end_date AS "rent_end_date",
-                i.id AS "invoice_id",
-                i.billing_period_start_date,
-                i.billing_period_end_date
-            FROM leasing_lease l
-            INNER JOIN leasing_leaseidentifier li
-                ON l.identifier_id = li.id
-            INNER JOIN leasing_rent r
-                ON l.id = r.lease_id
-            LEFT JOIN leasing_invoice i
-                ON l.id = i.lease_id
-            INNER JOIN leasing_invoicerow ir
-                ON i.id = ir.invoice_id
-            WHERE (l.end_date IS NULL OR l.end_date >= %(today)s)
-                AND (l.start_date IS NOT NULL AND l.start_date <= %(today)s)
-                AND l.service_unit_id = ANY(%(service_units)s)
-                AND l.deleted IS NULL
-                AND l.state NOT IN ('reservation', 'power_of_attorney')
-                AND r.deleted IS NULL
-                AND r."type" != 'free'
-                AND (r.start_date IS NULL OR r.start_date <= %(today)s)
-                AND (r.end_date IS NULL OR r.end_date >= %(today)s)
-                AND i.deleted IS NULL
-                AND i.deleted_by_cascade IS false
-                AND ir.deleted IS NULL
-                AND ir.receivable_type_id != ANY(%(excluded_receivable_type_ids)s)
-            ORDER BY li.identifier ASC;
+WITH invoices_sorted AS (
+    SELECT
+        i.id,
+        i.billing_period_start_date,
+        i.billing_period_end_date,
+        r.id AS rent_id,
+        l.id AS lease_id,
+        li.identifier AS lease_identifier,
+        COALESCE(c.name, (c.first_name || ' ' || c.last_name)) AS recipient_name,
+        COALESCE(r.start_date, l.start_date) AS rent_start_date,
+        COALESCE(r.end_date, l.end_date) AS rent_end_date,
+        LEAD(i.billing_period_start_date) OVER (PARTITION BY r.id ORDER BY i.billing_period_start_date) AS next_start_date
+    FROM
+        leasing_invoice i
+    INNER JOIN
+        leasing_invoicerow ir ON ir.invoice_id = i.id
+    LEFT JOIN
+        leasing_rent r ON i.lease_id = r.lease_id
+    INNER JOIN
+        leasing_lease l ON r.lease_id = l.id
+    INNER JOIN
+        leasing_leaseidentifier li ON l.identifier_id = li.id
+    LEFT JOIN
+        leasing_receivabletype rt ON ir.receivable_type_id = rt.id
+    LEFT JOIN
+        leasing_contact c ON i.recipient_id = c.id
+    WHERE
+        ir.deleted IS NULL
+        AND i.deleted IS NULL
+        AND i.type IN ('charge')
+        AND r.deleted IS NULL
+        AND r."type" NOT IN ('free', 'manual')
+        AND rt.name NOT IN (
+            'Korko',
+            'Yhteismarkkinointi (sis. ALV)',
+            'Kiinteistötoimitukset (tonttijaot, lohkomiset, rekisteröimiskustannukset, rasitteet)',
+            'Rahavakuus'
+            )
+        AND (r.start_date IS NULL OR r.start_date <= %(today)s)
+        AND (r.end_date IS NULL OR r.end_date >= %(today)s)
+        AND l.state IN ('lease', 'long_term_lease')
+        AND l.service_unit_id = ANY(%(service_units)s)
+),
+invoicing_gaps AS (
+    SELECT
+        rent_id,
+        lease_id,
+        lease_identifier,
+        recipient_name,
+        rent_start_date::date,
+        rent_end_date,
+        billing_period_start_date,
+        billing_period_end_date,
+        next_start_date,
+        CASE
+            WHEN (billing_period_end_date + interval '1 day') < next_start_date THEN TRUE
+            ELSE FALSE
+        END AS has_gap,
+        (billing_period_end_date + interval '1 day')::date AS gap_start_date,
+        COALESCE((next_start_date - interval '1 day')::date, rent_end_date) AS gap_end_date
+    FROM
+        invoices_sorted
+    WHERE
+        billing_period_end_date < next_start_date
+        OR (rent_end_date IS NOT NULL AND billing_period_end_date < rent_end_date)
+    ORDER BY
+        lease_id, billing_period_start_date
+)
+SELECT
+    rent_id,
+    lease_id,
+    lease_identifier,
+    recipient_name,
+    rent_start_date,
+    rent_end_date,
+    next_start_date,
+    gap_start_date,
+    gap_end_date
+FROM
+    invoicing_gaps
+WHERE
+    has_gap IS TRUE
+ORDER BY
+    lease_id, gap_start_date;
         """
 
         today = datetime.date.today()
-
-        excluded_receivable_type_ids: list[int] = [
-            id
-            for id in ReceivableType.objects.filter(
-                name__in=EXCLUDED_RECEIVABLE_TYPE_NAMES
-            ).values_list("id", flat=True)
-        ]
-
         cursor.execute(
             query,
             {
                 "service_units": service_unit_ids,
                 "today": today,
-                "excluded_receivable_type_ids": excluded_receivable_type_ids,
             },
         )
 
-        billing_periods_data: list[BillingPeriodDataRow] = dictfetchall(cursor)
+        invoicing_gaps: list[InvoicingGapsRow] = dictfetchall(cursor)
+        data: list[InvoicingReviewReportOutput] = []
 
-        data = []
-
-        for _, billing_period_data_row_group in groupby(
-            billing_periods_data, lambda x: x["lease_id"]
-        ):
-            lease_period_start = None
-            lease_period_end = None
-            lease_period_days = 0
-
-            invoiced_period_days = 0
-            lease_has_gaps = False
-
-            for billing_period_data_row in billing_period_data_row_group:
-                billing_period_increment = calculate_invoice_billing_period_days(
-                    billing_period_data_row["billing_period_start_date"],
-                    billing_period_data_row["billing_period_end_date"],
-                    today,
-                )
-
-                if billing_period_increment is None:
-                    lease_has_gaps = True
-                    break
-
-                invoiced_period_days += billing_period_increment
-
-            lease_period_start, lease_period_end = get_lease_period(
-                billing_period_data_row,
-                today,
+        for invoicing_gap in invoicing_gaps:
+            data.append(
+                {
+                    "section": None,
+                    "lease_identifier": invoicing_gap["lease_identifier"],
+                    "start_date": invoicing_gap["gap_start_date"],
+                    "end_date": invoicing_gap["gap_end_date"],
+                    "note": str(
+                        {
+                            "recipient_name": invoicing_gap["recipient_name"],
+                            "rent_id": invoicing_gap["rent_id"],
+                            "next_expected_invoice_start_date": str(
+                                invoicing_gap["next_start_date"]
+                            ),
+                        }
+                    ),
+                }
             )
-            lease_period_days = (lease_period_end - lease_period_start).days + 1
-
-            if lease_period_days != invoiced_period_days:
-                lease_has_gaps = True
-
-            if lease_has_gaps:
-                data.append(
-                    {
-                        "section": None,
-                        "lease_identifier": billing_period_data_row["lease_identifier"],
-                    }
-                )
-            lease_period_start = None
-            lease_period_end = None
-            lease_period_days = 0
-            invoiced_period_days = 0
-            lease_has_gaps = False
-
         return data
 
     def get_data(self, input_data):

--- a/leasing/report/utils.py
+++ b/leasing/report/utils.py
@@ -4,17 +4,25 @@ from typing import TypedDict
 from django.db.backends.utils import CursorWrapper
 
 
-class BillingPeriodDataRow(TypedDict):
+class InvoicingGapsRow(TypedDict):
     lease_identifier: str
     lease_id: int
-    start_date: date
-    end_date: date
+    gap_start_date: date
+    gap_end_date: date
+    next_start_date: date
     rent_id: int
     rent_start_date: date
     rent_end_date: date
     invoice_id: int
-    billing_period_start_date: date
-    billing_period_end_date: date
+    recipient_name: str
+
+
+class InvoicingReviewReportOutput(TypedDict):
+    section: str | None
+    lease_identifier: str | None
+    start_date: date | None
+    end_date: date | None
+    note: str | None
 
 
 # From Django docs
@@ -22,42 +30,3 @@ def dictfetchall(cursor: CursorWrapper):
     """Return all rows from a cursor as a dict"""
     columns = [col[0] for col in cursor.description]
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
-
-
-# Gaps in billing periods helpers
-
-
-def get_lease_period(
-    billing_period_data_row: BillingPeriodDataRow, today: date
-) -> tuple[date, date]:
-    """
-    Get the period of the lease with active rents to be compared with the billing periods of the lease's invoices.
-    """
-    start_date = billing_period_data_row["start_date"]
-    if (
-        not billing_period_data_row["end_date"]
-        or billing_period_data_row["end_date"] > today
-    ):
-        end_date = today
-    else:
-        end_date = billing_period_data_row["end_date"]
-
-    return start_date, end_date
-
-
-def calculate_invoice_billing_period_days(
-    start_date: date | None, end_date: date | None, today: date
-) -> int | None:
-    """
-    Calculate the billing period days for the invoice.
-    Returns None if there are missing dates.
-    Excludes invoices and parts of the billing periods that are in the future.
-    """
-    if start_date is None or end_date is None:
-        return None
-    if start_date > today:
-        return 0
-    current_end_date = today
-    if end_date < current_end_date:
-        current_end_date = end_date
-    return (current_end_date - start_date).days + 1

--- a/leasing/tests/report/test_reports.py
+++ b/leasing/tests/report/test_reports.py
@@ -18,7 +18,6 @@ from leasing.enums import DueDatesType, InvoiceState
 from leasing.report.invoice.invoicing_review import EXCLUDED_RECEIVABLE_TYPE_NAMES
 from leasing.report.invoice.laske_invoice_count_report import LaskeInvoiceCountReport
 from leasing.report.lease.lease_statistic_report import LeaseStatisticReport
-from leasing.report.utils import calculate_invoice_billing_period_days, get_lease_period
 from leasing.report.viewset import ENABLED_REPORTS
 
 
@@ -233,178 +232,11 @@ def test_laske_invoice_count_report(
     }
 
 
-def test_get_lease_period():
-
-    # Case 1: Set start and end dates.
-
-    row = {
-        "start_date": make_aware(datetime(2024, 1, 1)),
-        "end_date": make_aware(datetime(2024, 12, 31)),
-    }
-    today = make_aware(datetime(2025, 6, 15))
-    start, end = get_lease_period(row, today)
-    assert start == make_aware(datetime(2024, 1, 1))
-    assert end == make_aware(datetime(2024, 12, 31))
-
-    # Case 2: When lease end date is None, use today.
-
-    row = {
-        "start_date": make_aware(datetime(2024, 1, 1)),
-        "end_date": None,
-    }
-
-    today = make_aware(datetime(2025, 6, 15))
-    start, end = get_lease_period(row, today)
-    assert start == make_aware(datetime(2024, 1, 1))
-    assert end == make_aware(datetime(2025, 6, 15))
-
-    # Case 3: When lease end date is in the future, use today.
-
-    row = {
-        "start_date": make_aware(datetime(2024, 1, 1)),
-        "end_date": make_aware(datetime(2024, 12, 31)),
-    }
-
-    today = make_aware(datetime(2024, 6, 15))
-    start, end = get_lease_period(row, today)
-    assert start == make_aware(datetime(2024, 1, 1))
-    assert end == make_aware(datetime(2024, 6, 15))
-
-
-def test_calculate_invoice_billing_period_days():
-
-    # Case 1: Calculate billing period days for one month period.
-
-    row = {
-        "billing_period_start_date": make_aware(datetime(2024, 1, 1)),
-        "billing_period_end_date": make_aware(datetime(2024, 1, 31)),
-    }
-
-    today = make_aware(datetime(2024, 1, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        == 31
-    )
-
-    # Case 2: Calculate billing period days for a year period.
-
-    row = {
-        "billing_period_start_date": make_aware(datetime(2023, 1, 1)),
-        "billing_period_end_date": make_aware(datetime(2023, 12, 31)),
-    }
-
-    today = make_aware(datetime(2023, 12, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        == 365
-    )
-
-    # Case 3: Calculate billing period days for a leap year.
-
-    row = {
-        "billing_period_start_date": make_aware(datetime(2024, 1, 1)),
-        "billing_period_end_date": make_aware(datetime(2024, 12, 31)),
-    }
-
-    today = make_aware(datetime(2024, 12, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        == 366
-    )
-
-    # Case 4: Return None when start date is None.
-
-    row = {
-        "billing_period_start_date": None,
-        "billing_period_end_date": make_aware(datetime(2024, 1, 31)),
-    }
-
-    today = make_aware(datetime(2024, 1, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        is None
-    )
-
-    # Case 5: Return None when end date is None.
-
-    row = {
-        "billing_period_start_date": make_aware(datetime(2024, 1, 1)),
-        "billing_period_end_date": None,
-    }
-
-    today = make_aware(datetime(2024, 1, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        is None
-    )
-
-    # Case 6: Return None when both start and end dates are None.
-
-    row = {
-        "billing_period_start_date": None,
-        "billing_period_end_date": None,
-    }
-
-    today = make_aware(datetime(2024, 1, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        is None
-    )
-
-    # Case 7: Return 0 when start date is in the future.
-
-    row = {
-        "billing_period_start_date": make_aware(datetime(2024, 1, 1)),
-        "billing_period_end_date": make_aware(datetime(2024, 3, 31)),
-    }
-
-    today = make_aware(datetime(2023, 12, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        == 0
-    )
-
-    # Case 8: Return part of the days when end date is in the future.
-
-    row = {
-        "billing_period_start_date": make_aware(datetime(2024, 1, 1)),
-        "billing_period_end_date": make_aware(datetime(2024, 3, 31)),
-    }
-
-    today = make_aware(datetime(2024, 1, 31))
-
-    assert (
-        calculate_invoice_billing_period_days(
-            row["billing_period_start_date"], row["billing_period_end_date"], today
-        )
-        == 31
-    )
-
-
 def test_excluded_receivable_type_ids():
     """
     Tests that the excluded_receivable_type_ids are found in the fixture data.
+    These are utilized in `leasing/report/invoice/invoicing_review.py` function `get_gaps_in_billing_periods_data()`,
+    in an SQL query.
     """
     data = None
 


### PR DESCRIPTION
It was not possible to easily refactor the previous implementation that pulled hundreds of thousands of rows directly to memory.

This implements the logic fully as a SQL query, reducing the need to loads the rows into memory.
The approach for figuring out gaps in invoicing periods follows a completely different pattern. The idea in this implementation is to find missing periods for invoices by comparing the "current invoices billing_period_end_date" to the next rows start_date.