### PR TITLE
generate_areasearch_form: set companies as primary applicant type

### DIFF
--- a/forms/management/commands/generate_areasearch_form.py
+++ b/forms/management/commands/generate_areasearch_form.py
@@ -25,7 +25,7 @@ def initialize_area_search_form():
         identifier="hakija",
         enabled=True,
         required=False,
-        default_value="2",
+        default_value="1",
     )
     Choice.objects.create(
         field=applicant_field, text="Henkilö", value="2", has_text_input=False


### PR DESCRIPTION
The area search form sets person as the default applicant type. This changes it to company, so that it is pre-checked when the application page is opened.