### PR TITLE
tasotarkistus type enum labels

### DIFF
--- a/leasing/enums.py
+++ b/leasing/enums.py
@@ -701,9 +701,9 @@ class OldDwellingsInHousingCompaniesPriceIndexType(Enum):
     class Labels:
         TASOTARKISTUS_20_20 = pgettext_lazy(
             "Old dwellings in housing companies price index type",
-            "Tasotarkistus 20/20",
+            "Tasotarkistus 20v/20v",
         )
         TASOTARKISTUS_20_10 = pgettext_lazy(
             "Old dwellings in housing companies price index type",
-            "Tasotarkistus 20/10",
+            "Tasotarkistus 20v/10v",
         )


### PR DESCRIPTION
Just a small fix. Add "v" to the year intervals in the enum so that it matches the enum labels in the frontend.