### PR TITLE
MVJ-291 Remove KUVA as a standalone areasearch lessor

### DIFF
--- a/plotsearch/enums.py
+++ b/plotsearch/enums.py
@@ -8,7 +8,6 @@ class AreaSearchLessor(str, Enum):
     """
 
     AKV = "AKV"
-    KUVA = "KUVA"
     MAKE = "MAKE"
     LIPA = "LIPA"
     UPA = "UPA"
@@ -16,7 +15,6 @@ class AreaSearchLessor(str, Enum):
 
     class Labels:
         AKV = pgettext_lazy("Area search lessor", "Area use and control")
-        KUVA = pgettext_lazy("Area search lessor", "Culture and leisure")
         MAKE = pgettext_lazy("Area search lessor", "Development of land assets")
         LIPA = pgettext_lazy("Area search lessor", "Sports venue services")
         UPA = pgettext_lazy("Area search lessor", "Outdoor services")

--- a/plotsearch/utils.py
+++ b/plotsearch/utils.py
@@ -6,15 +6,6 @@ from plotsearch.enums import AreaSearchLessor
 
 
 def map_intended_use_to_lessor(intended_use):
-    # Keeping these for a transformation period
-    old_intended_uses_with_lessors = {
-        "myynti- ja mainontapaikat": AreaSearchLessor.AKV,
-        "taide- ja kulttuuripaikat": AreaSearchLessor.AKV,
-        "varasto- ja jakelualueet": AreaSearchLessor.AKV,
-        "työmaa tukikohdat ja alueet": AreaSearchLessor.AKV,
-        "veneily ja laiturialueet": AreaSearchLessor.KUVA,
-        "urheilu- ja liikuntapaikat": AreaSearchLessor.KUVA,
-    }
     intended_uses_with_lessors = {
         "ravitsemus, myynti ja mainonta": AreaSearchLessor.AKV,
         "taide ja kulttuuri": AreaSearchLessor.AKV,
@@ -25,9 +16,7 @@ def map_intended_use_to_lessor(intended_use):
         "urheilu ja liikunta": AreaSearchLessor.LIPA,
     }
     try:
-        lessor = {**intended_uses_with_lessors, **old_intended_uses_with_lessors}.get(
-            intended_use.name.lower(), None
-        )
+        lessor = intended_uses_with_lessors.get(intended_use.name.lower(), None)
     except AttributeError:
         return None
 


### PR DESCRIPTION
KuVa is represented as its three sub units LIPA, UPA, and NUP.

Also, remove obsolete mapping for removed intended uses. The old ones were not found in any of the running databases anymore.