### PR TITLE
Fix bug 'ExcelRow' object has no attribute 'keys'

### DIFF
--- a/leasing/report/report_base.py
+++ b/leasing/report/report_base.py
@@ -225,10 +225,8 @@ class ReportBase:
             row_num += 1
 
             lookup_row_num = 0
-            while (
-                lookup_row_num < len(data)
-                and lookup_row_num in data
-                and isinstance(data[lookup_row_num], ExcelRow)
+            while lookup_row_num < len(data) and isinstance(
+                data[lookup_row_num], ExcelRow
             ):
                 lookup_row_num += 1
 


### PR DESCRIPTION
This while loop is expected to identify each ExcelRow, and skip those in favour of dict-format rows.

Because `data` is a list, `lookup_row_num in data` incorrectly checked whether the integer value of lookup row number is a value on that row. This shorted the if-statement, which on a later line allowed invocation of method ExcelRow.keys(), which doesn't exist.