### PR TITLE
[WIP] MVJ-610 Setting start point figure for rent's tasotarkistus

### DIFF
--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -841,12 +841,25 @@ class Rent(TimeStampedSafeDeleteModel):
         return False
 
     def set_start_price_index_point_figure(self):
+        last_year_figure = None
+        latest_figure = None
+
         if self.old_dwellings_in_housing_companies_price_index:
-            start_index_number_yearly = IndexPointFigureYearly.objects.get(
+            all_index_point_figures = IndexPointFigureYearly.objects.filter(
                 index=self.old_dwellings_in_housing_companies_price_index,
-                year=self.lease.start_date.year - 1,
-            )
-            self.start_price_index_point_figure = start_index_number_yearly.value
+            ).order_by("-year")
+
+            last_year_figure = all_index_point_figures.filter(
+                year=self.lease.start_date.year - 1
+            ).first()
+            latest_figure = all_index_point_figures.first()
+
+        if last_year_figure is not None and last_year_figure.value:
+            self.start_price_index_point_figure = last_year_figure.value
+        elif latest_figure is not None and latest_figure.value:
+            self.start_price_index_point_figure = latest_figure.value
+        else:
+            self.start_price_index_point_figure = None
 
 
 class RentDueDate(TimeStampedSafeDeleteModel):

--- a/leasing/serializers/rent.py
+++ b/leasing/serializers/rent.py
@@ -453,7 +453,8 @@ class RentSerializer(
             "manual_ratio_previous",
             "override_receivable_type",
             "old_dwellings_in_housing_companies_price_index",
-            "periodic_rent_adjustment_type",
+            "start_price_index_point_figure",
+            "old_dwellings_in_housing_companies_price_index_type",
         )
 
     def override_permission_check_field_name(self, field_name):
@@ -570,6 +571,19 @@ class RentCreateUpdateSerializer(
             "old_dwellings_in_housing_companies_price_index",
             "periodic_rent_adjustment_type",
         )
+
+    def update(self, instance, validated_data):
+
+        if (
+            instance.old_dwellings_in_housing_companies_price_index is None
+            and validated_data.get("old_dwellings_in_housing_companies_price_index")
+            is not None
+        ):
+            instance.old_dwellings_in_housing_companies_price_index = (
+                validated_data.get("old_dwellings_in_housing_companies_price_index")
+            )
+            instance.set_start_price_index_point_figure()
+        return super().update(instance, validated_data)
 
     def validate(self, rent_data: dict):
         self.validate_override_receivable_type_value(rent_data)

--- a/leasing/tests/models/test_rent.py
+++ b/leasing/tests/models/test_rent.py
@@ -2887,3 +2887,38 @@ def test_set_start_price_index_point_figure_with_last_year_index(
     rent.set_start_price_index_point_figure()
 
     assert rent.start_price_index_point_figure == expected_point_figure.value
+
+
+@pytest.mark.django_db
+def test_set_start_price_index_point_figure_last_year_index_not_found(
+    rent_factory,
+    lease_factory,
+    old_dwellings_in_housing_companies_price_index_factory,
+    index_point_figure_yearly_factory,
+):
+    """The point figure should be set to the latest available index
+    if the year previous to the LEASE's start date is not found."""
+    lease = lease_factory(start_date=date(year=2026, month=1, day=1))
+    old_dwellings_in_housing_companies_price_index = (
+        old_dwellings_in_housing_companies_price_index_factory()
+    )
+    index_point_figure_yearly_factory(
+        value=101, year=2021, index=old_dwellings_in_housing_companies_price_index
+    )
+    index_point_figure_yearly_factory(
+        value=102, year=2022, index=old_dwellings_in_housing_companies_price_index
+    )
+    index_point_figure_yearly_factory(
+        value=103, year=2023, index=old_dwellings_in_housing_companies_price_index
+    )
+    expected_point_figure = index_point_figure_yearly_factory(
+        value=104, year=2024, index=old_dwellings_in_housing_companies_price_index
+    )
+    rent: Rent = rent_factory(
+        lease=lease,
+        old_dwellings_in_housing_companies_price_index=old_dwellings_in_housing_companies_price_index,
+    )
+
+    rent.set_start_price_index_point_figure()
+
+    assert rent.start_price_index_point_figure == expected_point_figure.value


### PR DESCRIPTION
When the `old_dwellings_in_housing_companies_price_index` is updated for the first time, the `start_price_index_point_figure` is set for that rent as well.

If the last year's index point figure doesn't exist yet, the current logic in this PR uses the latest available point figure. This might need to be changed so that it does not set it at all if the last year's point figure is not available yet.

SUGGESTIONS:
- If the logic  Change the start_price_index_point_figure from number to string, so for example: 100 => "2020 * 100" This would also reveal the year from which the index point figure comes from, not only the number itself.