### PR TITLE
set collateral types to line_item.wbs_element instead of profit_center

### DIFF
--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -259,9 +259,9 @@ class InvoiceSalesOrderAdapter:
             invoice_row.receivable_type
             == self.service_unit.default_receivable_type_collateral
         ):
-            # In case of collateral ("Rahavakuus") receivable type, populate the
-            # ProfitCenter element instead of OrderItemNumber element
             line_item.material = invoice_row.receivable_type.sap_material_code
+            # In case of collateral ("Rahavakuus") receivable type, populate the
+            # WBS_Element element instead of OrderItemNumber or (previously) ProfitCenter element
             # Use `sap_project_number` only, not `sap_order_item_number`.
             # Also discontinue setting the value to `line_item.profit_center`.
             line_item.wbs_element = invoice_row.receivable_type.sap_project_number

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -262,13 +262,9 @@ class InvoiceSalesOrderAdapter:
             # In case of collateral ("Rahavakuus") receivable type, populate the
             # ProfitCenter element instead of OrderItemNumber element
             line_item.material = invoice_row.receivable_type.sap_material_code
-            if invoice_row.receivable_type.sap_project_number is not None:
-                # If sap_project_number is set, use it over order_item_number
-                line_item.profit_center = invoice_row.receivable_type.sap_project_number
-            else:
-                line_item.profit_center = (
-                    invoice_row.receivable_type.sap_order_item_number
-                )
+            # Use `sap_project_number` only, not `sap_order_item_number`.
+            # Also discontinue setting the value to `line_item.profit_center`.
+            line_item.wbs_element = invoice_row.receivable_type.sap_project_number
         else:
             # Otherwise, use SAP codes from the InvoiceRow's receivable type
             line_item.material = invoice_row.receivable_type.sap_material_code

--- a/laske_export/tests/test_exporter_akv.py
+++ b/laske_export/tests/test_exporter_akv.py
@@ -199,6 +199,6 @@ def test_akv_sap_codes_when_collateral(
         == akv_default_test_setup["invoicerow1"].receivable_type.sap_material_code
     )
     assert (
-        line_item.find("ProfitCenter").text
+        line_item.find("WBS_Element").text
         == akv_default_test_setup["invoicerow1"].receivable_type.sap_project_number
     )


### PR DESCRIPTION
this leads to profit_center not being used.
accept only sap_project_number values, no order_item_numbers.