### PR TITLE
Mvj 572 sentry area import

### DIFF
--- a/leasing/importer/area.py
+++ b/leasing/importer/area.py
@@ -330,9 +330,7 @@ class AreaImporter(BaseImporter):
             self.area_types = []
             for area_type in options["area_types"].split(","):
                 if area_type not in AREA_IMPORT_TYPES.keys():
-                    raise RuntimeError(
-                        'Area import type "{}" doesn\'t exist'.format(area_type)
-                    )
+                    raise RuntimeError(f'Area import type "{area_type}" doesn\'t exist')
 
                 self.area_types.append(area_type)
 
@@ -368,9 +366,7 @@ class AreaImporter(BaseImporter):
 
         func_end = perf_counter()
         self.stdout.write(
-            "The area import is completed. Execution time: {0:.2f}s\n".format(
-                func_end - func_start
-            )
+            f"The area import is completed. Execution time: {func_end - func_start:.2f}s\n"
         )
 
     def get_metadata(
@@ -388,14 +384,12 @@ class AreaImporter(BaseImporter):
             }
             return metadata, error_count
         except AttributeError as e:
-            errors.append(
-                "id #{}, metadata field missing. Error: {}\n".format(row.id, str(e))
-            )
+            errors.append(f"id #{row.id}, metadata field missing. Error: {str(e)}\n")
 
             error_count += 1
             self.stdout.write("E")
             if error_count % 1000 == 0:
-                self.stdout.write(" {}".format(error_count))
+                self.stdout.write(f" {error_count}")
                 self.stdout.flush()
             return None, error_count
 
@@ -439,7 +433,7 @@ class AreaImporter(BaseImporter):
         dp_id = metadata.get("detailed_plan_identifier")
         if dp_id is None:
             self.stderr.write(
-                "detailed_plan_identifier not found for area #{}".format(identifier)
+                f"detailed_plan_identifier not found for area #{identifier}"
             )
             return None
 
@@ -450,12 +444,12 @@ class AreaImporter(BaseImporter):
             geom = geos.GEOSGeometry(row.geom_text)
             return geom, error_count
         except geos.error.GEOSException as e:
-            errors.append("id #{} error: {}\n".format(row.id, str(e)))
+            errors.append(f"id #{row.id} error: {str(e)}\n")
 
             error_count += 1
             self.stdout.write("E")
             if error_count % 1000 == 0:
-                self.stdout.write(" {}".format(error_count))
+                self.stdout.write(f" {error_count}")
                 self.stdout.flush()
             return None, error_count
 
@@ -471,15 +465,13 @@ class AreaImporter(BaseImporter):
 
         if geom and not isinstance(geom, geos.MultiPolygon):
             errors.append(
-                'id #{} Error! Geometry is not a Multipolygon but "{}"\n'.format(
-                    row.id, geom
-                )
+                f'id #{row.id} Error! Geometry is not a Multipolygon but "{geom}"\n'
             )
 
             error_count += 1
             self.stdout.write("E")
             if error_count % 1000 == 0:
-                self.stdout.write(" {}".format(error_count))
+                self.stdout.write(f" {error_count}")
                 self.stdout.flush()
             return None, error_count
 
@@ -517,7 +509,7 @@ class AreaImporter(BaseImporter):
         if error_count % 100 == 0:
             self.stdout.write(".")
         if error_count % 1000 == 0:
-            self.stdout.write(" {}".format(error_count))
+            self.stdout.write(f" {error_count}")
             self.stdout.flush()
         return imported_identifiers, error_count
 
@@ -578,10 +570,8 @@ class AreaImporter(BaseImporter):
             avg_row_time = sum_row_time / error_count
 
         self.stdout.write(
-            "Updated area count {}. Execution time: {:.2f}s "
-            "(Row time avg: {:.2f}s, min: {:.2f}s, max: {:.2f}s)\n".format(
-                error_count, sum_row_time, avg_row_time, min_row_time, max_row_time
-            )
+            f"Updated area count {error_count}. Execution time: {sum_row_time:.2f}s "
+            f"(Row time avg: {avg_row_time:.2f}s, min: {min_row_time:.2f}s, max: {max_row_time:.2f}s)\n"
         )
         return imported_identifiers
 
@@ -589,10 +579,7 @@ class AreaImporter(BaseImporter):
         type_start = perf_counter()
 
         errors: list[str] = []
-        errors: List[str] = []
-        self.stdout.write(
-            'Starting to import the area type "{}"...\n'.format(area_import_type)
-        )
+        self.stdout.write(f'Starting to import the area type "{area_import_type}"...\n')
 
         area_import = AREA_IMPORT_TYPES[area_import_type]
 
@@ -628,9 +615,7 @@ class AreaImporter(BaseImporter):
 
         type_end = perf_counter()
         self.stdout.write(
-            'The area import of type "{}" is completed. Execution time: {:.2f}s\n'.format(
-                area_import_type, (type_end - type_start)
-            )
+            f'The area import of type "{area_import_type}" is completed. Execution time: {type_end - type_start:.2f}s\n'
         )
 
     def handle_stale_areas(
@@ -645,7 +630,5 @@ class AreaImporter(BaseImporter):
         stale.delete()
         stale_time_end = perf_counter()
         self.stdout.write(
-            "Removed stale count {}. Execution time: {:.2f}s\n".format(
-                stale_count, stale_time_end - stale_time_start
-            )
+            f"Removed stale count {stale_count}. Execution time: {stale_time_end - stale_time_start:.2f}s\n"
         )

--- a/leasing/importer/area.py
+++ b/leasing/importer/area.py
@@ -1,6 +1,6 @@
 import logging
 from time import perf_counter
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypedDict
+from typing import Any, Dict, NamedTuple, Optional, Tuple, TypedDict
 
 import psycopg
 from django.conf import settings
@@ -26,7 +26,7 @@ class AreaImport(TypedDict, total=False):
     source_identifier: str
     area_type: AreaType
     identifier_field_name: str
-    metadata_columns: List[str]
+    metadata_columns: list[str]
     query: str
 
 
@@ -313,7 +313,7 @@ class AreaImporter(BaseImporter):
     def __init__(self, stdout=None, stderr=None):
         self.stdout = stdout
         self.stderr = stderr
-        self.area_types: List[AreaType] = []
+        self.area_types: list[AreaType] = []
 
     @classmethod
     def add_arguments(cls, parser):
@@ -378,7 +378,7 @@ class AreaImporter(BaseImporter):
         row: NamedTupleUnknown,
         area_import: AreaImport,
         column_name_map: Dict[str, str],
-        errors: List[str],
+        errors: list[str],
         error_count: int,
     ) -> Tuple[Optional[Metadata], int]:
         try:
@@ -445,7 +445,7 @@ class AreaImporter(BaseImporter):
 
         return areas.filter(metadata__detailed_plan_identifier=dp_id)
 
-    def get_geometry(self, row: NamedTupleUnknown, errors: List[str], error_count: int):
+    def get_geometry(self, row: NamedTupleUnknown, errors: list[str], error_count: int):
         try:
             geom = geos.GEOSGeometry(row.geom_text)
             return geom, error_count
@@ -463,7 +463,7 @@ class AreaImporter(BaseImporter):
         self,
         geom: geos.MultiPolygon,
         row: NamedTuple,
-        errors: List[str],
+        errors: list[str],
         error_count: int,
     ):
         if geom and isinstance(geom, geos.Polygon):
@@ -490,7 +490,7 @@ class AreaImporter(BaseImporter):
         areas: QuerySet[Area],
         update_data: UpdateData,
         match_data: MatchData,
-        imported_identifiers: List[str],
+        imported_identifiers: list[str],
         error_count: int,
     ) -> Tuple[list, int]:
         try:
@@ -526,9 +526,9 @@ class AreaImporter(BaseImporter):
         cursor: psycopg.Cursor[NamedTuple],
         area_import: AreaImport,
         source: AreaSource,
-        errors: List[str],
+        errors: list[str],
     ):
-        imported_identifiers: List[str] = []
+        imported_identifiers: list[str] = []
         error_count = 0
         sum_row_time, avg_row_time, min_row_time, max_row_time = (0.0,) * 4
         self.stdout.write("Starting to update areas...\n")
@@ -588,6 +588,7 @@ class AreaImporter(BaseImporter):
     def process_area_import_type(self, area_import_type: AreaType):
         type_start = perf_counter()
 
+        errors: list[str] = []
         errors: List[str] = []
         self.stdout.write(
             'Starting to import the area type "{}"...\n'.format(area_import_type)
@@ -633,7 +634,7 @@ class AreaImporter(BaseImporter):
         )
 
     def handle_stale_areas(
-        self, area_import: AreaImport, source: str, imported_identifiers: List[str]
+        self, area_import: AreaImport, source: str, imported_identifiers: list[str]
     ):
         self.stdout.write("Starting to remove stales...\n")
         stale_time_start = perf_counter()


### PR DESCRIPTION
The idea here is that Sentry would capture the logger errors. Not switching all of the logging to the logger due to `self.stdout` and `self.stderr` logging to the db.

I suggest to review the relevant commit separately, so you don't see the diff's for these f-string and typing adjustments