### PR TITLE
unify file downloads

### DIFF
--- a/forms/tests/test_api.py
+++ b/forms/tests/test_api.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import FileResponse
 from django.urls import reverse
 from django.utils import timezone
 from faker import Faker
@@ -405,11 +406,12 @@ def test_attachment_post(
     url = reverse("v1:answer-attachments", kwargs={"pk": id})
     response = admin_client.get(url)
     url = reverse("v1:attachment-download", kwargs={"pk": attachment_id})
-    file_request = admin_client.get(url)
+    file_response: FileResponse = admin_client.get(url)
     assert response.status_code == 200
     assert len(response.json()) != 0
-    assert file_request.status_code == 200
-    assert file_request.content == b"Lorem lipsum"
+    assert file_response.status_code == 200
+    # Get the content from the generator
+    assert b"".join(file_response.streaming_content) == b"Lorem lipsum"
 
 
 @pytest.mark.django_db

--- a/forms/viewsets/form.py
+++ b/forms/viewsets/form.py
@@ -170,6 +170,10 @@ class AttachmentViewSet(FileDownloadMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
+    @action(methods=["get"], detail=True)
+    def download(self, request, pk=None):
+        return super().download(request, pk, file_field="attachment")
+
 
 class TargetStatusViewset(
     mixins.UpdateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet

--- a/leasing/tests/api/test_infill_development_compensation.py
+++ b/leasing/tests/api/test_infill_development_compensation.py
@@ -3,6 +3,7 @@ from io import BytesIO
 
 import pytest
 from django.core.serializers.json import DjangoJSONEncoder
+from django.http import FileResponse
 from django.urls import reverse
 
 from leasing.models import (
@@ -83,7 +84,7 @@ def test_download_attachment(
     url = attachment_serializer.get_file_url(attachment)
 
     # anonymous shouldn't have the permission to download the file
-    response = client.get(url)
+    response: FileResponse = client.get(url)
     assert response.status_code == 401, "%s %s" % (response.status_code, response.data)
     assert response.data["detail"].code == "not_authenticated"
 
@@ -100,4 +101,5 @@ def test_download_attachment(
     assert response.get("Content-Disposition").startswith(
         'attachment; filename="dummy_file'
     )
-    assert response.content == b"dummy data"
+    # Get the content from the generator
+    assert b"".join(response.streaming_content) == b"dummy data"

--- a/leasing/tests/api/test_land_use_agreement.py
+++ b/leasing/tests/api/test_land_use_agreement.py
@@ -518,7 +518,8 @@ def test_download_attachment(
     assert response.get("Content-Disposition").startswith(
         'attachment; filename="dummy_file'
     )
-    assert response.content == b"dummy data"
+    # Get the content from the generator
+    assert b"".join(response.streaming_content) == b"dummy data"
 
 
 def test_create_invoice(contact_factory, admin_client, land_use_agreement_test_data):

--- a/leasing/viewsets/debt_collection.py
+++ b/leasing/viewsets/debt_collection.py
@@ -19,11 +19,8 @@ from leasing.serializers.debt_collection import (
     CollectionNoteCreateUpdateSerializer,
     CollectionNoteSerializer,
 )
-from leasing.viewsets.utils import (
-    AtomicTransactionModelViewSet,
-    FileMixin,
-    MultiPartJsonParser,
-)
+from leasing.viewsets.utils import AtomicTransactionModelViewSet, MultiPartJsonParser
+from utils.viewsets.mixins import FileMixin
 
 
 class CollectionCourtDecisionViewSet(

--- a/leasing/viewsets/infill_development_compensation.py
+++ b/leasing/viewsets/infill_development_compensation.py
@@ -13,8 +13,9 @@ from leasing.serializers.infill_development_compensation import (
     InfillDevelopmentCompensationCreateUpdateSerializer,
     InfillDevelopmentCompensationSerializer,
 )
+from utils.viewsets.mixins import FileMixin
 
-from .utils import AtomicTransactionModelViewSet, FileMixin, MultiPartJsonParser
+from .utils import AtomicTransactionModelViewSet, MultiPartJsonParser
 
 
 class InfillDevelopmentCompensationViewSet(

--- a/leasing/viewsets/inspection.py
+++ b/leasing/viewsets/inspection.py
@@ -4,8 +4,9 @@ from leasing.serializers.inspection import (
     InspectionAttachmentCreateUpdateSerializer,
     InspectionAttachmentSerializer,
 )
+from utils.viewsets.mixins import FileMixin
 
-from .utils import AtomicTransactionModelViewSet, FileMixin, MultiPartJsonParser
+from .utils import AtomicTransactionModelViewSet, MultiPartJsonParser
 
 
 class InspectionAttachmentViewSet(

--- a/leasing/viewsets/land_area.py
+++ b/leasing/viewsets/land_area.py
@@ -14,8 +14,9 @@ from leasing.serializers.land_area import (
     PlotIdentifierSerializer,
 )
 from plotsearch.models import PlotSearch, PlotSearchTarget
+from utils.viewsets.mixins import FileMixin
 
-from .utils import AtomicTransactionModelViewSet, FileMixin, MultiPartJsonParser
+from .utils import AtomicTransactionModelViewSet, MultiPartJsonParser
 
 
 class LeaseAreaAttachmentViewSet(

--- a/leasing/viewsets/land_use_agreement.py
+++ b/leasing/viewsets/land_use_agreement.py
@@ -47,8 +47,9 @@ from leasing.serializers.land_use_agreement import (
     SentToSapLandUseAgreementInvoiceUpdateSerializer,
 )
 from leasing.serializers.receivable_type import ReceivableTypeSerializer
+from utils.viewsets.mixins import FileMixin
 
-from .utils import AtomicTransactionModelViewSet, FileMixin, MultiPartJsonParser
+from .utils import AtomicTransactionModelViewSet, MultiPartJsonParser
 
 
 def get_object_from_query_params(object_type, query_params):

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -399,6 +399,10 @@ class AreaSearchAttachmentViewset(
             return qs
         return qs.filter(user=self.request.user)
 
+    @action(methods=["get"], detail=True)
+    def download(self, request, pk=None):
+        return super().download(self, request, pk, file_field="attachment")
+
 
 class InformationCheckViewSet(
     mixins.ListModelMixin,

--- a/plotsearch/views/plot_search.py
+++ b/plotsearch/views/plot_search.py
@@ -6,7 +6,6 @@ from zipfile import ZipInfo
 
 import xlsxwriter
 from django import http
-from django.core.files import File
 from django.http import HttpResponse, QueryDict
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -85,6 +84,7 @@ from plotsearch.serializers.plot_search import (
     RelatedPlotApplicationCreateDeleteSerializer,
 )
 from plotsearch.utils import build_pdf_context
+from utils.viewsets.mixins import FileDownloadMixin
 
 
 class PlotSearchSubtypeViewSet(
@@ -376,7 +376,10 @@ class AreaSearchPublicViewSet(
 
 
 class AreaSearchAttachmentViewset(
-    mixins.CreateModelMixin, mixins.DestroyModelMixin, viewsets.GenericViewSet
+    FileDownloadMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
 ):
     queryset = AreaSearchAttachment.objects.all()
     serializer_class = AreaSearchAttachmentSerializer
@@ -395,18 +398,6 @@ class AreaSearchAttachmentViewset(
         if user.has_perm("plotsearch.view_areasearchattachment"):
             return qs
         return qs.filter(user=self.request.user)
-
-    @action(methods=["get"], detail=True)
-    def download(self, request, pk=None):
-        obj = self.get_object()
-        with obj.attachment.open() as fp:
-            # TODO: detect file MIME type
-            response = HttpResponse(File(fp), content_type="application/octet-stream")
-            response["Content-Disposition"] = 'attachment; filename="{}"'.format(
-                obj.name
-            )
-
-            return response
 
 
 class InformationCheckViewSet(

--- a/utils/viewsets/mixins.py
+++ b/utils/viewsets/mixins.py
@@ -7,11 +7,14 @@ from rest_framework.response import Response
 
 class FileDownloadMixin:
     @action(methods=["get"], detail=True)
-    def download(self, request, pk=None):
+    def download(self, request, pk=None, file_field: str | None = None):
         obj = self.get_object()
-
-        filename = "/".join([settings.MEDIA_ROOT, obj.file.name])
-        response = FileResponse(open(filename, "rb"), as_attachment=True)
+        if file_field is not None:
+            filename = getattr(obj, file_field).name
+        else:
+            filename = obj.file.name
+        filepath = "/".join([settings.MEDIA_ROOT, filename])
+        response = FileResponse(open(filepath, "rb"), as_attachment=True)
 
         return response
 
@@ -60,5 +63,5 @@ class FileMixin:
         return Response(read_serializer.data)
 
     @action(methods=["get"], detail=True)
-    def download(self, request, pk=None):
-        return FileDownloadMixin.download(self, request, pk)
+    def download(self, request, pk=None, file_field: str | None = None):
+        return FileDownloadMixin.download(self, request, pk, file_field=file_field)

--- a/utils/viewsets/mixins.py
+++ b/utils/viewsets/mixins.py
@@ -1,0 +1,64 @@
+from django.conf import settings
+from django.http import FileResponse
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+
+class FileDownloadMixin:
+    @action(methods=["get"], detail=True)
+    def download(self, request, pk=None):
+        obj = self.get_object()
+
+        filename = "/".join([settings.MEDIA_ROOT, obj.file.name])
+        response = FileResponse(open(filename, "rb"), as_attachment=True)
+
+        return response
+
+
+class FileMixin:
+    def create(self, request, *args, **kwargs):
+        """Use the Class.serializer_class after the creation for returning the saved data.
+        Instead of a different serializer used in 'create' action."""
+        if not self.serializer_class:
+            return super().create(request, *args, **kwargs)
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+
+        read_serializer = self.serializer_class(
+            serializer.instance, context=serializer.context
+        )
+
+        headers = self.get_success_headers(read_serializer.data)
+        return Response(
+            read_serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+    def update(self, request, *args, **kwargs):
+        """Use the Class.serializer_class after update for returning the saved data.
+        Instead of a different serializer used in 'update' action."""
+        if not self.serializer_class:
+            return super().create(request, *args, **kwargs)
+
+        partial = kwargs.pop("partial", False)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+
+        if getattr(instance, "_prefetched_objects_cache", None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
+
+        read_serializer = self.serializer_class(
+            serializer.instance, context=serializer.context
+        )
+
+        return Response(read_serializer.data)
+
+    @action(methods=["get"], detail=True)
+    def download(self, request, pk=None):
+        return FileDownloadMixin.download(self, request, pk)


### PR DESCRIPTION
* split download from FileMixin to FileDownloadMixin
* move FileMixin (and FileDownloadMixin) from leasing.viewsets.utils to utils.viewsets.mixins
*  use FileResponse in place of HttpResponse in DownloadMixin.download(), which handles the mimetype checking (from file extension), adds Content-Length header, and handles file closure
* replace duplicated download() methods in viewsets with FileDownloadMixin for: AttachmentViewSet, and AreaSearchAttachmentViewset