### PR TITLE
Area search viewset filter: fix preparer filter

### DIFF
--- a/plotsearch/filter.py
+++ b/plotsearch/filter.py
@@ -126,7 +126,7 @@ class AreaSearchFilterSet(django_filters.FilterSet):
     start_date = django_filters.DateFromToRangeFilter()
     end_date = django_filters.DateFromToRangeFilter()
     address = django_filters.CharFilter(lookup_expr="icontains")
-    preparer = django_filters.CharFilter(field_name="preparer__username")
+    preparer = django_filters.CharFilter(field_name="preparer__id")
     applicant = ApplicantFilter()
     service_unit = django_filters.NumberFilter(field_name="service_unit__id")
     q = AreaSearchSimpleFilter()


### PR DESCRIPTION
Area search list view did not filter by preparer properly. The reason was that the api calls use id, but the filterset used username for some reason. Now it is changed to using id.