### PR TITLE
PRIVATE_FILES_LOCATION to runtime env vars

### DIFF
--- a/.github/workflows/mvj-ci.yml
+++ b/.github/workflows/mvj-ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     env:
       DATABASE_URL: 'postgis://postgres:postgres@localhost/github_actions'
+      PRIVATE_FILES_LOCATION: '/tmp/private_files'
 
     runs-on: ubuntu-22.04
     strategy:

--- a/file_operations/private_files.py
+++ b/file_operations/private_files.py
@@ -16,7 +16,7 @@ class PrivateFileSystemStorage(FileSystemStorage):
     def __init__(self) -> None:
         # Raise an error if the PRIVATE_FILES_LOCATION setting is not set
         # To avoid resolving the location as the MEDIA_ROOT by default
-        if bool(settings.PRIVATE_FILES_LOCATION) is not True:
+        if len(settings.PRIVATE_FILES_LOCATION) == 0:
             raise ValueError("PRIVATE_FILES_LOCATION setting is not set")
         super().__init__(location=settings.PRIVATE_FILES_LOCATION, base_url=None)
 

--- a/file_operations/private_files.py
+++ b/file_operations/private_files.py
@@ -14,10 +14,11 @@ class PrivateFileSystemStorage(FileSystemStorage):
     """
 
     def __init__(self) -> None:
-        # Raise an error if the PRIVATE_FILES_LOCATION setting is not set
+        # Raise an error if the PRIVATE_FILES_LOCATION setting is not configured
         # To avoid resolving the location as the MEDIA_ROOT by default
+
         if len(settings.PRIVATE_FILES_LOCATION) == 0:
-            raise ValueError("PRIVATE_FILES_LOCATION setting is not set")
+            raise ValueError("PRIVATE_FILES_LOCATION setting is not configured")
         super().__init__(location=settings.PRIVATE_FILES_LOCATION, base_url=None)
 
 

--- a/file_operations/private_files.py
+++ b/file_operations/private_files.py
@@ -14,7 +14,10 @@ class PrivateFileSystemStorage(FileSystemStorage):
     """
 
     def __init__(self) -> None:
-        # base_url is not needed, but it defaults to MEDIA_URL if not explicitly set
+        # Raise an error if the PRIVATE_FILES_LOCATION setting is not set
+        # To avoid resolving the location as the MEDIA_ROOT by default
+        if bool(settings.PRIVATE_FILES_LOCATION) is not True:
+            raise ValueError("PRIVATE_FILES_LOCATION setting is not set")
         super().__init__(location=settings.PRIVATE_FILES_LOCATION, base_url=None)
 
 

--- a/local_settings.py.template
+++ b/local_settings.py.template
@@ -15,3 +15,5 @@ FLAG_FILE_SCAN = True
 FILE_SCAN_SERVICE_URL = (
     "https://*****/api/v1/scan"  # Prefer the devtest endpoint
 )
+
+PRIVATE_FILES_LOCATION = "/code/private_files"

--- a/mvj/settings.py
+++ b/mvj/settings.py
@@ -113,6 +113,7 @@ env = environ.Env(
     FILE_SCAN_SERVICE_URL=(str, ""),
     FLAG_FILE_SCAN=(bool, False),
     FLAG_PLOTSEARCH=(bool, False),
+    PRIVATE_FILES_LOCATION=(str, ""),
 )
 
 env_file = project_root(".env")
@@ -141,7 +142,7 @@ if env("SENTRY_DSN"):
 
 MEDIA_ROOT = project_root("media")
 STATIC_ROOT = project_root("static")
-PRIVATE_FILES_LOCATION = project_root("private_files")
+PRIVATE_FILES_LOCATION = env.str("PRIVATE_FILES_LOCATION")
 
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"


### PR DESCRIPTION
Background: File not found error described on the ticket [MVJ-716](https://helsinkisolutionoffice.atlassian.net/browse/MVJ-716)

A more long-term solution for resolving the environment variable, without relying on the `local_settings.py`

[MVJ-716]: https://helsinkisolutionoffice.atlassian.net/browse/MVJ-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ