### PR TITLE
replace sonarcloud action with sonarqube drop-in replacement

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,8 +45,8 @@ jobs:
       run: |
         python manage.py compilemessages
         pytest --cov=. --cov-report xml:coverage.xml --migrations
-    - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
+    - name: SonarQube Scan
+      uses: sonarsource/sonarqube-scan-action@master
       with:
         args: >
           -Dsonar.organization=managedcloudapplications


### PR DESCRIPTION
"Warning: This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action."

This was in CI logs