### PR TITLE
MVJ-642 link to leases in reports

### DIFF
--- a/leasing/report/invoice/collaterals_report.py
+++ b/leasing/report/invoice/collaterals_report.py
@@ -5,11 +5,14 @@ from leasing.models import Collateral, CollateralType, ServiceUnit
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_id(obj):
+def get_lease_ids(obj):
     if not obj.contract.lease:
         return
 
-    return obj.contract.lease.get_identifier_string()
+    return {
+        "id": obj.contract.lease.id,
+        "identifier": obj.contract.lease.get_identifier_string(),
+    }
 
 
 def get_start_date(obj):
@@ -46,7 +49,7 @@ class CollateralsReport(ReportBase):
         "returned": forms.NullBooleanField(label=_("Returned"), required=False),
     }
     output_fields = {
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
         "start_date": {
             "source": get_start_date,
             "label": _("Lease start date"),

--- a/leasing/report/invoice/collaterals_report.py
+++ b/leasing/report/invoice/collaterals_report.py
@@ -53,7 +53,7 @@ class CollateralsReport(ReportBase):
         "returned": forms.NullBooleanField(label=_("Returned"), required=False),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_collateral,
             "label": _("Lease id"),
         },

--- a/leasing/report/invoice/collaterals_report.py
+++ b/leasing/report/invoice/collaterals_report.py
@@ -2,16 +2,17 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from leasing.models import Collateral, CollateralType, ServiceUnit
+from leasing.report.lease.common_getters import LeaseIds
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_ids(obj):
-    if not obj.contract.lease:
-        return
+def get_lease_ids_from_collateral(collateral: Collateral) -> LeaseIds:
+    if not collateral.contract.lease:
+        return {"id": None, "identifier": None}
 
     return {
-        "id": obj.contract.lease.id,
-        "identifier": obj.contract.lease.get_identifier_string(),
+        "id": collateral.contract.lease.id,
+        "identifier": collateral.contract.lease.identifier,
     }
 
 
@@ -49,7 +50,7 @@ class CollateralsReport(ReportBase):
         "returned": forms.NullBooleanField(label=_("Returned"), required=False),
     }
     output_fields = {
-        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
+        "lease_ids": {"source": get_lease_ids_from_collateral, "label": _("Lease id")},
         "start_date": {
             "source": get_start_date,
             "label": _("Lease start date"),

--- a/leasing/report/invoice/collaterals_report.py
+++ b/leasing/report/invoice/collaterals_report.py
@@ -7,13 +7,16 @@ from leasing.report.report_base import ReportBase
 
 
 def get_lease_link_data_from_collateral(collateral: Collateral) -> LeaseLinkData:
-    if not collateral.contract.lease:
-        return {"id": None, "identifier": None}
-
-    return {
-        "id": collateral.contract.lease.id,
-        "identifier": collateral.contract.lease.identifier,
-    }
+    try:
+        return {
+            "id": collateral.contract.lease.id,
+            "identifier": collateral.contract.lease.get_identifier_string(),
+        }
+    except AttributeError:
+        return {
+            "id": None,
+            "identifier": None,
+        }
 
 
 def get_start_date(obj):

--- a/leasing/report/invoice/collaterals_report.py
+++ b/leasing/report/invoice/collaterals_report.py
@@ -2,11 +2,11 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from leasing.models import Collateral, CollateralType, ServiceUnit
-from leasing.report.lease.common_getters import LeaseIds
+from leasing.report.lease.common_getters import LeaseLinkData
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_ids_from_collateral(collateral: Collateral) -> LeaseIds:
+def get_lease_link_data_from_collateral(collateral: Collateral) -> LeaseLinkData:
     if not collateral.contract.lease:
         return {"id": None, "identifier": None}
 
@@ -50,7 +50,10 @@ class CollateralsReport(ReportBase):
         "returned": forms.NullBooleanField(label=_("Returned"), required=False),
     }
     output_fields = {
-        "lease_ids": {"source": get_lease_ids_from_collateral, "label": _("Lease id")},
+        "lease_link_data": {
+            "source": get_lease_link_data_from_collateral,
+            "label": _("Lease id"),
+        },
         "start_date": {
             "source": get_start_date,
             "label": _("Lease start date"),

--- a/leasing/report/invoice/invoice_payments.py
+++ b/leasing/report/invoice/invoice_payments.py
@@ -50,7 +50,7 @@ class InvoicePaymentsReport(ReportBase):
             "label": _("Invoice number"),
             "is_numeric": True,
         },
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_invoice_payment,
             "label": _("Lease id"),
         },

--- a/leasing/report/invoice/invoice_payments.py
+++ b/leasing/report/invoice/invoice_payments.py
@@ -13,8 +13,11 @@ def get_invoice_number(obj):
     return obj.invoice.number
 
 
-def get_lease_id(obj):
-    return obj.invoice.lease.get_identifier_string()
+def get_lease_ids(obj):
+    return {
+        "id": obj.invoice.lease.id,
+        "identifier": obj.invoice.lease.get_identifier_string(),
+    }
 
 
 class InvoicePaymentsReport(ReportBase):
@@ -38,7 +41,7 @@ class InvoicePaymentsReport(ReportBase):
             "label": _("Invoice number"),
             "is_numeric": True,
         },
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
         "paid_date": {"label": _("Paid date"), "format": "date"},
         "paid_amount": {"label": _("Paid amount"), "format": "money", "width": 13},
         "filing_code": {"label": _("Filing code")},

--- a/leasing/report/invoice/invoice_payments.py
+++ b/leasing/report/invoice/invoice_payments.py
@@ -17,10 +17,16 @@ def get_invoice_number(obj):
 def get_lease_link_data_from_invoice_payment(
     invoice_payment: InvoicePayment,
 ) -> LeaseLinkData:
-    return {
-        "id": invoice_payment.invoice.lease.id,
-        "identifier": invoice_payment.invoice.lease.get_identifier_string(),
-    }
+    try:
+        return {
+            "id": invoice_payment.invoice.lease.id,
+            "identifier": invoice_payment.invoice.lease.get_identifier_string(),
+        }
+    except AttributeError:
+        return {
+            "id": None,
+            "identifier": None,
+        }
 
 
 class InvoicePaymentsReport(ReportBase):

--- a/leasing/report/invoice/invoice_payments.py
+++ b/leasing/report/invoice/invoice_payments.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from leasing.models import ServiceUnit
 from leasing.models.invoice import InvoicePayment
 from leasing.report.excel import ExcelCell, ExcelRow, SumCell
+from leasing.report.lease.common_getters import LeaseLinkData
 from leasing.report.report_base import ReportBase
 
 
@@ -13,10 +14,12 @@ def get_invoice_number(obj):
     return obj.invoice.number
 
 
-def get_lease_ids(obj):
+def get_lease_link_data_from_invoice_payment(
+    invoice_payment: InvoicePayment,
+) -> LeaseLinkData:
     return {
-        "id": obj.invoice.lease.id,
-        "identifier": obj.invoice.lease.get_identifier_string(),
+        "id": invoice_payment.invoice.lease.id,
+        "identifier": invoice_payment.invoice.lease.get_identifier_string(),
     }
 
 
@@ -41,7 +44,10 @@ class InvoicePaymentsReport(ReportBase):
             "label": _("Invoice number"),
             "is_numeric": True,
         },
-        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
+        "lease_link_data": {
+            "source": get_lease_link_data_from_invoice_payment,
+            "label": _("Lease id"),
+        },
         "paid_date": {"label": _("Paid date"), "format": "date"},
         "paid_amount": {"label": _("Paid amount"), "format": "money", "width": 13},
         "filing_code": {"label": _("Filing code")},

--- a/leasing/report/invoice/invoices_in_period.py
+++ b/leasing/report/invoice/invoices_in_period.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from leasing.enums import InvoiceState
 from leasing.models import Invoice, LeaseType, ServiceUnit
 from leasing.report.excel import ExcelCell, ExcelRow, SumCell
-from leasing.report.lease.common_getters import get_lease_ids_from_related_object
+from leasing.report.lease.common_getters import get_lease_link_data_from_related_object
 from leasing.report.report_base import ReportBase
 
 
@@ -63,8 +63,8 @@ class InvoicesInPeriodReport(ReportBase):
             "label": _("Receivable type"),
         },
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_ids": {
-            "source": get_lease_ids_from_related_object,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },
         "state": {

--- a/leasing/report/invoice/invoices_in_period.py
+++ b/leasing/report/invoice/invoices_in_period.py
@@ -7,15 +7,12 @@ from rest_framework.response import Response
 from leasing.enums import InvoiceState
 from leasing.models import Invoice, LeaseType, ServiceUnit
 from leasing.report.excel import ExcelCell, ExcelRow, SumCell
+from leasing.report.lease.common_getters import get_lease_ids
 from leasing.report.report_base import ReportBase
 
 
 def get_lease_type(obj):
     return obj.lease.identifier.type.identifier
-
-
-def get_lease_id(obj):
-    return obj.lease.get_identifier_string()
 
 
 def get_recipient_name(obj):
@@ -66,7 +63,7 @@ class InvoicesInPeriodReport(ReportBase):
             "label": _("Receivable type"),
         },
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
         "state": {
             "label": _("State"),
             "serializer_field": EnumField(enum=InvoiceState),

--- a/leasing/report/invoice/invoices_in_period.py
+++ b/leasing/report/invoice/invoices_in_period.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from leasing.enums import InvoiceState
 from leasing.models import Invoice, LeaseType, ServiceUnit
 from leasing.report.excel import ExcelCell, ExcelRow, SumCell
-from leasing.report.lease.common_getters import get_lease_ids
+from leasing.report.lease.common_getters import get_lease_ids_from_related_object
 from leasing.report.report_base import ReportBase
 
 
@@ -63,7 +63,10 @@ class InvoicesInPeriodReport(ReportBase):
             "label": _("Receivable type"),
         },
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_related_object,
+            "label": _("Lease id"),
+        },
         "state": {
             "label": _("State"),
             "serializer_field": EnumField(enum=InvoiceState),

--- a/leasing/report/invoice/invoices_in_period.py
+++ b/leasing/report/invoice/invoices_in_period.py
@@ -63,7 +63,7 @@ class InvoicesInPeriodReport(ReportBase):
             "label": _("Receivable type"),
         },
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },

--- a/leasing/report/invoice/invoicing_review.py
+++ b/leasing/report/invoice/invoicing_review.py
@@ -302,7 +302,7 @@ class InvoicingReviewReport(ReportBase):
             "label": pgettext_lazy("Invoicing review", "Section"),
             "serializer_field": EnumField(enum=InvoicingReviewSection),
         },
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_report_row,
             "label": gettext_lazy("Lease id"),
         },

--- a/leasing/report/invoice/invoicing_review.py
+++ b/leasing/report/invoice/invoicing_review.py
@@ -16,11 +16,12 @@ from rest_framework.response import Response
 
 from leasing.models import ServiceUnit
 from leasing.report.excel import FormatType
+from leasing.report.lease.common_getters import LeaseIds
 from leasing.report.lease.invoicing_disabled_report import INVOICING_DISABLED_REPORT_SQL
 from leasing.report.report_base import ReportBase
 from leasing.report.utils import (
     InvoicingGapsRow,
-    InvoicingReviewReportOutput,
+    InvoicingReviewReportRow,
     dictfetchall,
 )
 
@@ -34,6 +35,26 @@ EXCLUDED_RECEIVABLE_TYPE_NAMES = [
     "Kiinteistötoimitukset (tonttijaot, lohkomiset, rekisteröimiskustannukset, rasitteet)",
     "Rahavakuus",
 ]
+
+
+def get_lease_ids_from_report_row(
+    row: InvoicingReviewReportRow | InvoicingGapsRow,
+) -> LeaseIds:
+    try:
+        if row["section"]:
+            return {
+                "id": None,
+                "identifier": None,
+            }
+        return {
+            "id": row["lease_id"],
+            "identifier": row["lease_identifier"],
+        }
+    except KeyError:
+        return {
+            "id": None,
+            "identifier": None,
+        }
 
 
 class InvoicingReviewSection(Enum):
@@ -87,6 +108,7 @@ INVOICING_REVIEW_QUERIES = {
     "rent_info_not_complete": """
         SELECT NULL AS "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -105,6 +127,7 @@ INVOICING_REVIEW_QUERIES = {
     "no_rents": """
         SELECT NULL AS "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -130,6 +153,7 @@ INVOICING_REVIEW_QUERIES = {
     "no_due_date": """
         SELECT NULL AS "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -164,6 +188,7 @@ INVOICING_REVIEW_QUERIES = {
     "index_type_missing": """
         SELECT NULL as "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -187,6 +212,7 @@ INVOICING_REVIEW_QUERIES = {
     "one_time_rents_with_no_invoice_max_5year_old_leases": """
         SELECT NULL as "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -211,6 +237,7 @@ INVOICING_REVIEW_QUERIES = {
     "no_tenant_contact": """
         SELECT NULL as "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -239,6 +266,7 @@ INVOICING_REVIEW_QUERIES = {
     "no_lease_area": """
         SELECT NULL AS "section",
             li.identifier AS "lease_identifier",
+            l.id AS "lease_id",
             l.start_date,
             l.end_date
         FROM leasing_lease l
@@ -274,7 +302,10 @@ class InvoicingReviewReport(ReportBase):
             "label": pgettext_lazy("Invoicing review", "Section"),
             "serializer_field": EnumField(enum=InvoicingReviewSection),
         },
-        "lease_identifier": {"label": gettext_lazy("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_report_row,
+            "label": gettext_lazy("Lease id"),
+        },
         "start_date": {"label": gettext_lazy("Start date"), "format": "date"},
         "end_date": {"label": gettext_lazy("End date"), "format": "date"},
         "note": {"label": gettext_lazy("Note")},
@@ -289,6 +320,7 @@ class InvoicingReviewReport(ReportBase):
 
         query = """
             SELECT li.identifier as lease_identifier,
+                   l.id AS lease_id,
                    l.start_date,
                    l.end_date,
                    array_agg(share) AS shares
@@ -351,6 +383,7 @@ class InvoicingReviewReport(ReportBase):
 
         query = """
             SELECT li.identifier as lease_identifier,
+                   l.id AS lease_id,
                    l.start_date,
                    l.end_date
               FROM leasing_lease l
@@ -407,6 +440,7 @@ class InvoicingReviewReport(ReportBase):
 
         query = """
             SELECT li.identifier as "lease_identifier",
+                   l.id AS "lease_id",
                    l."start_date",
                    l."end_date",
                    array_agg(tt.share) AS "shares"
@@ -561,13 +595,14 @@ ORDER BY
         )
 
         invoicing_gaps: list[InvoicingGapsRow] = dictfetchall(cursor)
-        data: list[InvoicingReviewReportOutput] = []
+        data: list[InvoicingReviewReportRow] = []
 
         for invoicing_gap in invoicing_gaps:
             data.append(
                 {
                     "section": None,
                     "lease_identifier": invoicing_gap["lease_identifier"],
+                    "lease_id": invoicing_gap["lease_id"],
                     "start_date": invoicing_gap["gap_start_date"],
                     "end_date": invoicing_gap["gap_end_date"],
                     "note": str(
@@ -621,6 +656,7 @@ ORDER BY
                         {
                             "section": None,
                             "lease_identifier": None,
+                            "lease_id": None,
                             "start_date": None,
                             "end_date": None,
                             "note": f"Query error when generating report: {e}",

--- a/leasing/report/invoice/invoicing_review.py
+++ b/leasing/report/invoice/invoicing_review.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 
 from leasing.models import ServiceUnit
 from leasing.report.excel import FormatType
-from leasing.report.lease.common_getters import LeaseIds
+from leasing.report.lease.common_getters import LeaseLinkData
 from leasing.report.lease.invoicing_disabled_report import INVOICING_DISABLED_REPORT_SQL
 from leasing.report.report_base import ReportBase
 from leasing.report.utils import (
@@ -37,9 +37,9 @@ EXCLUDED_RECEIVABLE_TYPE_NAMES = [
 ]
 
 
-def get_lease_ids_from_report_row(
+def get_lease_link_data_from_report_row(
     row: InvoicingReviewReportRow | InvoicingGapsRow,
-) -> LeaseIds:
+) -> LeaseLinkData:
     try:
         if row["section"]:
             return {
@@ -302,8 +302,8 @@ class InvoicingReviewReport(ReportBase):
             "label": pgettext_lazy("Invoicing review", "Section"),
             "serializer_field": EnumField(enum=InvoicingReviewSection),
         },
-        "lease_ids": {
-            "source": get_lease_ids_from_report_row,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_report_row,
             "label": gettext_lazy("Lease id"),
         },
         "start_date": {"label": gettext_lazy("Start date"), "format": "date"},

--- a/leasing/report/invoice/open_invoices_report.py
+++ b/leasing/report/invoice/open_invoices_report.py
@@ -45,7 +45,7 @@ class OpenInvoicesReport(ReportBase):
     output_fields = {
         "number": {"label": _("Number")},
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },

--- a/leasing/report/invoice/open_invoices_report.py
+++ b/leasing/report/invoice/open_invoices_report.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from leasing.enums import InvoiceState
 from leasing.models import Invoice, ServiceUnit
 from leasing.report.excel import ExcelCell, ExcelRow, PreviousRowsSumCell, SumCell
-from leasing.report.lease.common_getters import get_lease_ids
+from leasing.report.lease.common_getters import get_lease_ids_from_related_object
 from leasing.report.report_base import ReportBase
 
 
@@ -45,7 +45,10 @@ class OpenInvoicesReport(ReportBase):
     output_fields = {
         "number": {"label": _("Number")},
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_related_object,
+            "label": _("Lease id"),
+        },
         "due_date": {"label": _("Due date"), "format": "date"},
         "total_amount": {"label": _("Total amount"), "format": "money", "width": 13},
         "billed_amount": {"label": _("Billed amount"), "format": "money", "width": 13},

--- a/leasing/report/invoice/open_invoices_report.py
+++ b/leasing/report/invoice/open_invoices_report.py
@@ -9,15 +9,12 @@ from rest_framework.response import Response
 from leasing.enums import InvoiceState
 from leasing.models import Invoice, ServiceUnit
 from leasing.report.excel import ExcelCell, ExcelRow, PreviousRowsSumCell, SumCell
+from leasing.report.lease.common_getters import get_lease_ids
 from leasing.report.report_base import ReportBase
 
 
 def get_lease_type(obj):
     return obj.lease.identifier.type.identifier
-
-
-def get_lease_id(obj):
-    return obj.lease.get_identifier_string()
 
 
 def get_recipient_name(obj):
@@ -48,7 +45,7 @@ class OpenInvoicesReport(ReportBase):
     output_fields = {
         "number": {"label": _("Number")},
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
         "due_date": {"label": _("Due date"), "format": "date"},
         "total_amount": {"label": _("Total amount"), "format": "money", "width": 13},
         "billed_amount": {"label": _("Billed amount"), "format": "money", "width": 13},

--- a/leasing/report/invoice/open_invoices_report.py
+++ b/leasing/report/invoice/open_invoices_report.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from leasing.enums import InvoiceState
 from leasing.models import Invoice, ServiceUnit
 from leasing.report.excel import ExcelCell, ExcelRow, PreviousRowsSumCell, SumCell
-from leasing.report.lease.common_getters import get_lease_ids_from_related_object
+from leasing.report.lease.common_getters import get_lease_link_data_from_related_object
 from leasing.report.report_base import ReportBase
 
 
@@ -45,8 +45,8 @@ class OpenInvoicesReport(ReportBase):
     output_fields = {
         "number": {"label": _("Number")},
         "lease_type": {"source": get_lease_type, "label": _("Lease type")},
-        "lease_ids": {
-            "source": get_lease_ids_from_related_object,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },
         "due_date": {"label": _("Due date"), "format": "date"},

--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -19,8 +19,8 @@ def get_lease_type(lease):
     return lease.identifier.type.identifier
 
 
-def get_lease_id(lease):
-    return lease.get_identifier_string()
+def get_lease_ids(lease):
+    return {"id": lease.id, "identifier": lease.get_identifier_string()}
 
 
 def get_tenants(lease, include_future_tenants=False, report=None):

--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -54,6 +54,13 @@ def get_lease_link_data_from_related_object(
         }
 
 
+def get_identifier_string_from_lease_link_data(row: dict) -> str:
+    try:
+        return row["lease_identifier"]["identifier"]
+    except KeyError:
+        return "-"
+
+
 def get_tenants(lease, include_future_tenants=False, report=None):
     today = datetime.date.today()
 

--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -42,13 +42,16 @@ def get_lease_link_data(lease: Lease) -> LeaseLinkData:
 def get_lease_link_data_from_related_object(
     lease_related_object: LeaseRelatedModel,
 ) -> LeaseLinkData:
-    if not lease_related_object.lease:
-        return {"id": None, "identifier": None}
-
-    return {
-        "id": lease_related_object.lease.id,
-        "identifier": lease_related_object.lease.get_identifier_string(),
-    }
+    try:
+        return {
+            "id": lease_related_object.lease.id,
+            "identifier": lease_related_object.lease.get_identifier_string(),
+        }
+    except AttributeError:
+        return {
+            "id": None,
+            "identifier": None,
+        }
 
 
 def get_tenants(lease, include_future_tenants=False, report=None):

--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Protocol
+from typing import Protocol, TypedDict
 
 from django.db.models import QuerySet
 
@@ -12,7 +12,9 @@ RE_LEASE_DECISION_TYPE_ID = 29  # Vuokraus (sopimuksen uusiminen/jatkam.)
 OPTION_TO_PURCHASE_CONDITION_TYPE_ID = 24  # 24 = Osto-optioehto
 
 
-class LeaseIds(Protocol):
+class LeaseLinkData(TypedDict):
+    """Data required to show lease identifier with a link to that lease on reports."""
+
     id: int | None
     identifier: str | None
 
@@ -33,13 +35,13 @@ def get_lease_identifier_string(lease: Lease) -> str:
     return lease.get_identifier_string()
 
 
-def get_lease_ids(lease: Lease) -> LeaseIds:
+def get_lease_link_data(lease: Lease) -> LeaseLinkData:
     return {"id": lease.id, "identifier": lease.get_identifier_string()}
 
 
-def get_lease_ids_from_related_object(
+def get_lease_link_data_from_related_object(
     lease_related_object: LeaseRelatedModel,
-) -> LeaseIds:
+) -> LeaseLinkData:
     if not lease_related_object.lease:
         return {"id": None, "identifier": None}
 

--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -56,7 +56,7 @@ def get_lease_link_data_from_related_object(
 
 def get_identifier_string_from_lease_link_data(row: dict) -> str:
     try:
-        return row["lease_identifier"]["identifier"]
+        return row["lease_identifier"]["identifier"] or "-"
     except KeyError:
         return "-"
 

--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -5,10 +5,20 @@ from django.db.models import QuerySet
 
 from leasing.enums import TenantContactType
 from leasing.models import Contract
+from leasing.models.lease import Lease
 
 RE_LEASE_DECISION_TYPE_ID = 29  # Vuokraus (sopimuksen uusiminen/jatkam.)
 
 OPTION_TO_PURCHASE_CONDITION_TYPE_ID = 24  # 24 = Osto-optioehto
+
+
+class LeaseIds(Protocol):
+    id: int | None
+    identifier: str | None
+
+
+class LeaseRelatedModel(Protocol):
+    lease: Lease
 
 
 class LeaseWithContracts(Protocol):
@@ -19,8 +29,24 @@ def get_lease_type(lease):
     return lease.identifier.type.identifier
 
 
-def get_lease_ids(lease):
+def get_lease_identifier_string(lease: Lease) -> str:
+    return lease.get_identifier_string()
+
+
+def get_lease_ids(lease: Lease) -> LeaseIds:
     return {"id": lease.id, "identifier": lease.get_identifier_string()}
+
+
+def get_lease_ids_from_related_object(
+    lease_related_object: LeaseRelatedModel,
+) -> LeaseIds:
+    if not lease_related_object.lease:
+        return {"id": None, "identifier": None}
+
+    return {
+        "id": lease_related_object.lease.id,
+        "identifier": lease_related_object.lease.get_identifier_string(),
+    }
 
 
 def get_tenants(lease, include_future_tenants=False, report=None):

--- a/leasing/report/lease/contact_rents.py
+++ b/leasing/report/lease/contact_rents.py
@@ -13,7 +13,7 @@ from leasing.models.types import TenantShares
 from leasing.report.lease.common_getters import (
     get_address,
     get_lease_area_identifier,
-    get_lease_ids,
+    get_lease_link_data,
     get_tenants,
 )
 from leasing.report.report_base import ReportBase
@@ -31,9 +31,9 @@ class ContactRentsReport(ReportBase):
         "contact_id": forms.IntegerField(label=_("Contact identifier"), required=True),
     }
     output_fields = {
-        "lease_ids": {
+        "lease_link_data": {
             "label": _("Lease identifier"),
-            "source": get_lease_ids,
+            "source": get_lease_link_data,
             "width": 13,
         },
         "lease_area_identifier": {

--- a/leasing/report/lease/contact_rents.py
+++ b/leasing/report/lease/contact_rents.py
@@ -31,7 +31,7 @@ class ContactRentsReport(ReportBase):
         "contact_id": forms.IntegerField(label=_("Contact identifier"), required=True),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "label": _("Lease identifier"),
             "source": get_lease_link_data,
             "width": 13,

--- a/leasing/report/lease/contact_rents.py
+++ b/leasing/report/lease/contact_rents.py
@@ -13,7 +13,7 @@ from leasing.models.types import TenantShares
 from leasing.report.lease.common_getters import (
     get_address,
     get_lease_area_identifier,
-    get_lease_id,
+    get_lease_ids,
     get_tenants,
 )
 from leasing.report.report_base import ReportBase
@@ -31,9 +31,9 @@ class ContactRentsReport(ReportBase):
         "contact_id": forms.IntegerField(label=_("Contact identifier"), required=True),
     }
     output_fields = {
-        "lease_id": {
+        "lease_ids": {
             "label": _("Lease identifier"),
-            "source": get_lease_id,
+            "source": get_lease_ids,
             "width": 13,
         },
         "lease_area_identifier": {

--- a/leasing/report/lease/decision_conditions_report.py
+++ b/leasing/report/lease/decision_conditions_report.py
@@ -5,7 +5,7 @@ from leasing.models import Condition, ConditionType, ServiceUnit
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_ids(obj):
+def get_lease_ids_from_decision_condition(obj):
     return {
         "id": obj.decision.lease.id,
         "identifier": obj.decision.lease.get_identifier_string(),
@@ -83,7 +83,10 @@ class DecisionConditionsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_decision_condition,
+            "label": _("Lease id"),
+        },
         "area": {"source": get_area, "label": _("Lease area"), "width": 30},
         "address": {"source": get_address, "label": _("Address"), "width": 50},
         "type": {"source": get_condition_type, "label": _("Type"), "width": 25},

--- a/leasing/report/lease/decision_conditions_report.py
+++ b/leasing/report/lease/decision_conditions_report.py
@@ -5,8 +5,11 @@ from leasing.models import Condition, ConditionType, ServiceUnit
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_id(obj):
-    return obj.decision.lease.get_identifier_string()
+def get_lease_ids(obj):
+    return {
+        "id": obj.decision.lease.id,
+        "identifier": obj.decision.lease.get_identifier_string(),
+    }
 
 
 def get_condition_type(obj):
@@ -80,7 +83,7 @@ class DecisionConditionsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {"source": get_lease_ids, "label": _("Lease id")},
         "area": {"source": get_area, "label": _("Lease area"), "width": 30},
         "address": {"source": get_address, "label": _("Address"), "width": 50},
         "type": {"source": get_condition_type, "label": _("Type"), "width": 25},

--- a/leasing/report/lease/decision_conditions_report.py
+++ b/leasing/report/lease/decision_conditions_report.py
@@ -5,7 +5,7 @@ from leasing.models import Condition, ConditionType, ServiceUnit
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_ids_from_decision_condition(obj):
+def get_lease_link_data_from_decision_condition(obj):
     return {
         "id": obj.decision.lease.id,
         "identifier": obj.decision.lease.get_identifier_string(),
@@ -83,8 +83,8 @@ class DecisionConditionsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {
-            "source": get_lease_ids_from_decision_condition,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_decision_condition,
             "label": _("Lease id"),
         },
         "area": {"source": get_area, "label": _("Lease area"), "width": 30},

--- a/leasing/report/lease/decision_conditions_report.py
+++ b/leasing/report/lease/decision_conditions_report.py
@@ -2,14 +2,21 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from leasing.models import Condition, ConditionType, ServiceUnit
+from leasing.report.lease.common_getters import LeaseLinkData
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_link_data_from_decision_condition(obj):
-    return {
-        "id": obj.decision.lease.id,
-        "identifier": obj.decision.lease.get_identifier_string(),
-    }
+def get_lease_link_data_from_decision_condition(condition: Condition) -> LeaseLinkData:
+    try:
+        return {
+            "id": condition.decision.lease.id,
+            "identifier": condition.decision.lease.get_identifier_string(),
+        }
+    except AttributeError:
+        return {
+            "id": None,
+            "identifier": None,
+        }
 
 
 def get_condition_type(obj):

--- a/leasing/report/lease/decision_conditions_report.py
+++ b/leasing/report/lease/decision_conditions_report.py
@@ -90,7 +90,7 @@ class DecisionConditionsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_decision_condition,
             "label": _("Lease id"),
         },

--- a/leasing/report/lease/extra_city_rent.py
+++ b/leasing/report/lease/extra_city_rent.py
@@ -112,7 +112,7 @@ class ExtraCityRentReport(ReportBase):
         "end_date": forms.DateField(label=_("End date"), required=True),
     }
     output_fields = {
-        "lease_link_data": {"label": _("Lease id")},
+        "lease_identifier": {"label": _("Lease id")},
         "tenant_name": {"label": _("Tenant name"), "width": 50},
         "area_identifier": {"label": _("Area identifier"), "width": 50},
         "area": {"label": _("Area amount"), "format": "area"},
@@ -198,7 +198,7 @@ class ExtraCityRentReport(ReportBase):
             aggregated_data.append(
                 {
                     "municipality_name": lease.identifier.municipality.name,
-                    "lease_link_data": get_lease_link_data(lease),
+                    "lease_identifier": get_lease_link_data(lease),
                     "tenant_name": ", ".join([c.get_name() for c in contacts]),
                     "area_identifier": ", ".join(
                         [

--- a/leasing/report/lease/extra_city_rent.py
+++ b/leasing/report/lease/extra_city_rent.py
@@ -18,14 +18,8 @@ from leasing.report.excel import (
     PreviousRowsSumCell,
     SumCell,
 )
+from leasing.report.lease.common_getters import get_lease_link_data
 from leasing.report.report_base import ReportBase
-
-
-def get_lease_ids(obj):
-    return {
-        "id": obj.lease.id,
-        "identifier": obj.lease.get_identifier_string(),
-    }
 
 
 def get_recipient_address(obj):
@@ -118,7 +112,7 @@ class ExtraCityRentReport(ReportBase):
         "end_date": forms.DateField(label=_("End date"), required=True),
     }
     output_fields = {
-        "lease_ids": {"label": _("Lease id")},
+        "lease_link_data": {"label": _("Lease id")},
         "tenant_name": {"label": _("Tenant name"), "width": 50},
         "area_identifier": {"label": _("Area identifier"), "width": 50},
         "area": {"label": _("Area amount"), "format": "area"},
@@ -204,7 +198,7 @@ class ExtraCityRentReport(ReportBase):
             aggregated_data.append(
                 {
                     "municipality_name": lease.identifier.municipality.name,
-                    "lease_ids": get_lease_ids(lease),
+                    "lease_link_data": get_lease_link_data(lease),
                     "tenant_name": ", ".join([c.get_name() for c in contacts]),
                     "area_identifier": ", ".join(
                         [

--- a/leasing/report/lease/extra_city_rent.py
+++ b/leasing/report/lease/extra_city_rent.py
@@ -118,7 +118,7 @@ class ExtraCityRentReport(ReportBase):
         "end_date": forms.DateField(label=_("End date"), required=True),
     }
     output_fields = {
-        "lease_id": {"label": _("Lease id")},
+        "lease_ids": {"label": _("Lease id")},
         "tenant_name": {"label": _("Tenant name"), "width": 50},
         "area_identifier": {"label": _("Area identifier"), "width": 50},
         "area": {"label": _("Area amount"), "format": "area"},
@@ -204,7 +204,7 @@ class ExtraCityRentReport(ReportBase):
             aggregated_data.append(
                 {
                     "municipality_name": lease.identifier.municipality.name,
-                    "lease_id": get_lease_ids(lease),
+                    "lease_ids": get_lease_ids(lease),
                     "tenant_name": ", ".join([c.get_name() for c in contacts]),
                     "area_identifier": ", ".join(
                         [

--- a/leasing/report/lease/extra_city_rent.py
+++ b/leasing/report/lease/extra_city_rent.py
@@ -21,6 +21,13 @@ from leasing.report.excel import (
 from leasing.report.report_base import ReportBase
 
 
+def get_lease_ids(obj):
+    return {
+        "id": obj.lease.id,
+        "identifier": obj.lease.get_identifier_string(),
+    }
+
+
 def get_recipient_address(obj):
     return ", ".join(
         filter(
@@ -197,7 +204,7 @@ class ExtraCityRentReport(ReportBase):
             aggregated_data.append(
                 {
                     "municipality_name": lease.identifier.municipality.name,
-                    "lease_id": lease.get_identifier_string(),
+                    "lease_id": get_lease_ids(lease),
                     "tenant_name": ", ".join([c.get_name() for c in contacts]),
                     "area_identifier": ", ".join(
                         [

--- a/leasing/report/lease/index_types.py
+++ b/leasing/report/lease/index_types.py
@@ -91,7 +91,7 @@ class IndexTypesReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },

--- a/leasing/report/lease/index_types.py
+++ b/leasing/report/lease/index_types.py
@@ -7,11 +7,8 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import IndexType, TenantContactType
 from leasing.models import Rent, ServiceUnit
+from leasing.report.lease.common_getters import get_lease_ids_from_related_object
 from leasing.report.report_base import ReportBase
-
-
-def get_lease_id(rent: Rent) -> str:
-    return rent.lease.get_identifier_string()
 
 
 def get_tenants(rent: Rent) -> str:
@@ -94,7 +91,10 @@ class IndexTypesReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_related_object,
+            "label": _("Lease id"),
+        },
         "tenant_name": {"source": get_tenants, "label": _("Tenant name"), "width": 50},
         "lease_area_identifier": {
             "source": get_area_id,

--- a/leasing/report/lease/index_types.py
+++ b/leasing/report/lease/index_types.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import IndexType, TenantContactType
 from leasing.models import Rent, ServiceUnit
-from leasing.report.lease.common_getters import get_lease_ids_from_related_object
+from leasing.report.lease.common_getters import get_lease_link_data_from_related_object
 from leasing.report.report_base import ReportBase
 
 
@@ -91,8 +91,8 @@ class IndexTypesReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {
-            "source": get_lease_ids_from_related_object,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },
         "tenant_name": {"source": get_tenants, "label": _("Tenant name"), "width": 50},

--- a/leasing/report/lease/invoicing_disabled_report.py
+++ b/leasing/report/lease/invoicing_disabled_report.py
@@ -9,13 +9,19 @@ from leasing.report.report_base import ReportBase
 from leasing.report.utils import InvoicingDisabledReportRow, dictfetchall
 
 
-def get_lease_link_data_for_invoicing_disabled_report(
+def get_lease_link_data_from_invoicing_disabled_report_row(
     disabled_report_row: InvoicingDisabledReportRow,
 ) -> LeaseLinkData:
-    return {
-        "id": disabled_report_row["lease_id"],
-        "identifier": disabled_report_row["lease_identifier"],
-    }
+    try:
+        return {
+            "id": disabled_report_row["lease_id"],
+            "identifier": disabled_report_row["lease_identifier"],
+        }
+    except KeyError:
+        return {
+            "id": None,
+            "identifier": None,
+        }
 
 
 INVOICING_DISABLED_REPORT_SQL = """
@@ -56,7 +62,7 @@ class LeaseInvoicingDisabledReport(ReportBase):
     }
     output_fields = {
         "lease_link_data": {
-            "source": get_lease_link_data_for_invoicing_disabled_report,
+            "source": get_lease_link_data_from_invoicing_disabled_report_row,
             "label": _("Lease id"),
         },
         "start_date": {"label": _("Start date"), "format": "date"},

--- a/leasing/report/lease/invoicing_disabled_report.py
+++ b/leasing/report/lease/invoicing_disabled_report.py
@@ -7,9 +7,18 @@ from leasing.models import ServiceUnit
 from leasing.report.report_base import ReportBase
 from leasing.report.utils import dictfetchall
 
+
+def get_lease_ids_for_invoicing_disabled_report(obj):
+    return {
+        "id": obj["lease_id"],
+        "identifier": obj["lease_identifier"],
+    }
+
+
 INVOICING_DISABLED_REPORT_SQL = """
     SELECT NULL AS "section",
         li.identifier AS "lease_identifier",
+        l.id AS "lease_id",
         l.start_date,
         l.end_date
     FROM leasing_lease l
@@ -43,7 +52,10 @@ class LeaseInvoicingDisabledReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_identifier": {"label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_for_invoicing_disabled_report,
+            "label": _("Lease id"),
+        },
         "start_date": {"label": _("Start date"), "format": "date"},
         "end_date": {"label": _("End date"), "format": "date"},
     }

--- a/leasing/report/lease/invoicing_disabled_report.py
+++ b/leasing/report/lease/invoicing_disabled_report.py
@@ -4,14 +4,17 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from leasing.models import ServiceUnit
+from leasing.report.lease.common_getters import LeaseLinkData
 from leasing.report.report_base import ReportBase
-from leasing.report.utils import dictfetchall
+from leasing.report.utils import InvoicingDisabledReportRow, dictfetchall
 
 
-def get_lease_ids_for_invoicing_disabled_report(obj):
+def get_lease_link_data_for_invoicing_disabled_report(
+    disabled_report_row: InvoicingDisabledReportRow,
+) -> LeaseLinkData:
     return {
-        "id": obj["lease_id"],
-        "identifier": obj["lease_identifier"],
+        "id": disabled_report_row["lease_id"],
+        "identifier": disabled_report_row["lease_identifier"],
     }
 
 
@@ -52,8 +55,8 @@ class LeaseInvoicingDisabledReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {
-            "source": get_lease_ids_for_invoicing_disabled_report,
+        "lease_link_data": {
+            "source": get_lease_link_data_for_invoicing_disabled_report,
             "label": _("Lease id"),
         },
         "start_date": {"label": _("Start date"), "format": "date"},

--- a/leasing/report/lease/invoicing_disabled_report.py
+++ b/leasing/report/lease/invoicing_disabled_report.py
@@ -61,7 +61,7 @@ class LeaseInvoicingDisabledReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_invoicing_disabled_report_row,
             "label": _("Lease id"),
         },

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -18,7 +18,7 @@ from leasing.report.lease.common_getters import (
     get_form_of_regulation,
     get_latest_contract_number,
     get_lease_area_identifier,
-    get_lease_ids,
+    get_lease_identifier_string,
     get_lease_type,
     get_lessor,
     get_notice_period,
@@ -416,7 +416,7 @@ class LeaseStatisticReport(AsyncReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"label": _("Lease id"), "source": get_lease_ids},
+        "lease_id": {"label": _("Lease id"), "source": get_lease_identifier_string},
         # Sopimusnumero
         "contract_number": {
             "label": _("Contract number"),

--- a/leasing/report/lease/lease_statistic_report.py
+++ b/leasing/report/lease/lease_statistic_report.py
@@ -18,7 +18,7 @@ from leasing.report.lease.common_getters import (
     get_form_of_regulation,
     get_latest_contract_number,
     get_lease_area_identifier,
-    get_lease_id,
+    get_lease_ids,
     get_lease_type,
     get_lessor,
     get_notice_period,
@@ -416,7 +416,7 @@ class LeaseStatisticReport(AsyncReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"label": _("Lease id"), "source": get_lease_id},
+        "lease_id": {"label": _("Lease id"), "source": get_lease_ids},
         # Sopimusnumero
         "contract_number": {
             "label": _("Contract number"),

--- a/leasing/report/lease/lease_statistic_report2.py
+++ b/leasing/report/lease/lease_statistic_report2.py
@@ -17,7 +17,7 @@ from leasing.report.lease.common_getters import (
     get_form_of_regulation,
     get_latest_contract_number,
     get_lease_area_identifier,
-    get_lease_id,
+    get_lease_identifier_string,
     get_lease_type,
     get_lessor,
     get_notice_period,
@@ -238,7 +238,7 @@ class LeaseStatisticReport2(AsyncReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"label": _("Lease id"), "source": get_lease_id},
+        "lease_id": {"label": _("Lease id"), "source": get_lease_identifier_string},
         # Sopimusnumero
         "contract_number": {
             "label": _("Contract number"),

--- a/leasing/report/lease/rent_adjustments.py
+++ b/leasing/report/lease/rent_adjustments.py
@@ -13,16 +13,16 @@ from leasing.report.report_base import ReportBase
 def get_lease_link_data_from_rent_adjustment(
     rent_adjustment: RentAdjustment,
 ) -> LeaseLinkData:
-    if not rent_adjustment.rent.lease:
+    try:
+        return {
+            "id": rent_adjustment.rent.lease.id,
+            "identifier": rent_adjustment.rent.lease.get_identifier_string(),
+        }
+    except AttributeError:
         return {
             "id": None,
             "identifier": None,
         }
-
-    return {
-        "id": rent_adjustment.rent.lease.id,
-        "identifier": rent_adjustment.rent.lease.get_identifier_string(),
-    }
 
 
 def get_intended_use(obj):

--- a/leasing/report/lease/rent_adjustments.py
+++ b/leasing/report/lease/rent_adjustments.py
@@ -61,7 +61,7 @@ class RentAdjustmentsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_rent_adjustment,
             "label": _("Lease id"),
         },

--- a/leasing/report/lease/rent_adjustments.py
+++ b/leasing/report/lease/rent_adjustments.py
@@ -6,11 +6,13 @@ from enumfields.drf import EnumField
 
 from leasing.enums import RentAdjustmentAmountType, RentAdjustmentType, SubventionType
 from leasing.models import RentAdjustment, ServiceUnit
-from leasing.report.lease.common_getters import LeaseIds
+from leasing.report.lease.common_getters import LeaseLinkData
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_ids_from_rent_adjustment(rent_adjustment: RentAdjustment) -> LeaseIds:
+def get_lease_link_data_from_rent_adjustment(
+    rent_adjustment: RentAdjustment,
+) -> LeaseLinkData:
     if not rent_adjustment.rent.lease:
         return {
             "id": None,
@@ -59,8 +61,8 @@ class RentAdjustmentsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {
-            "source": get_lease_ids_from_rent_adjustment,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_rent_adjustment,
             "label": _("Lease id"),
         },
         "type": {

--- a/leasing/report/lease/rent_adjustments.py
+++ b/leasing/report/lease/rent_adjustments.py
@@ -6,11 +6,21 @@ from enumfields.drf import EnumField
 
 from leasing.enums import RentAdjustmentAmountType, RentAdjustmentType, SubventionType
 from leasing.models import RentAdjustment, ServiceUnit
+from leasing.report.lease.common_getters import LeaseIds
 from leasing.report.report_base import ReportBase
 
 
-def get_lease_id(obj):
-    return obj.rent.lease.get_identifier_string()
+def get_lease_ids_from_rent_adjustment(rent_adjustment: RentAdjustment) -> LeaseIds:
+    if not rent_adjustment.rent.lease:
+        return {
+            "id": None,
+            "identifier": None,
+        }
+
+    return {
+        "id": rent_adjustment.rent.lease.id,
+        "identifier": rent_adjustment.rent.lease.get_identifier_string(),
+    }
 
 
 def get_intended_use(obj):
@@ -49,7 +59,10 @@ class RentAdjustmentsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_rent_adjustment,
+            "label": _("Lease id"),
+        },
         "type": {
             "label": _("Type"),
             "serializer_field": EnumField(enum=RentAdjustmentType),

--- a/leasing/report/lease/rent_compare.py
+++ b/leasing/report/lease/rent_compare.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import RentType
 from leasing.models import Lease, ServiceUnit
+from leasing.report.lease.common_getters import get_lease_identifier_string
 from leasing.report.report_base import AsyncReportBase
 
 
@@ -28,7 +29,7 @@ class RentCompareReport(AsyncReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"label": _("Lease identifier"), "width": 13},
+        "lease_ids": {"label": _("Lease identifier"), "width": 13},
         "start_date": {"label": "Start date", "format": "date"},
         "end_date": {"label": "End date", "format": "date"},
         "rent_type": {"label": _("Rent type")},
@@ -109,7 +110,7 @@ class RentCompareReport(AsyncReportBase):
         results = []
         for lease in leases:
             result = {
-                "lease_id": lease.get_identifier_string(),
+                "lease_ids": get_lease_identifier_string(lease),
                 "start_date": lease.start_date,
                 "end_date": lease.end_date,
                 "rent_type": None,

--- a/leasing/report/lease/rent_compare.py
+++ b/leasing/report/lease/rent_compare.py
@@ -29,7 +29,7 @@ class RentCompareReport(AsyncReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {"label": _("Lease identifier"), "width": 13},
+        "lease_link_data": {"label": _("Lease identifier"), "width": 13},
         "start_date": {"label": "Start date", "format": "date"},
         "end_date": {"label": "End date", "format": "date"},
         "rent_type": {"label": _("Rent type")},
@@ -110,7 +110,7 @@ class RentCompareReport(AsyncReportBase):
         results = []
         for lease in leases:
             result = {
-                "lease_ids": get_lease_identifier_string(lease),
+                "lease_link_data": get_lease_identifier_string(lease),
                 "start_date": lease.start_date,
                 "end_date": lease.end_date,
                 "rent_type": None,

--- a/leasing/report/lease/rent_compare.py
+++ b/leasing/report/lease/rent_compare.py
@@ -29,7 +29,7 @@ class RentCompareReport(AsyncReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {"label": _("Lease identifier"), "width": 13},
+        "lease_identifier": {"label": _("Lease identifier"), "width": 13},
         "start_date": {"label": "Start date", "format": "date"},
         "end_date": {"label": "End date", "format": "date"},
         "rent_type": {"label": _("Rent type")},
@@ -110,7 +110,7 @@ class RentCompareReport(AsyncReportBase):
         results = []
         for lease in leases:
             result = {
-                "lease_link_data": get_lease_identifier_string(lease),
+                "lease_identifier": get_lease_identifier_string(lease),
                 "start_date": lease.start_date,
                 "end_date": lease.end_date,
                 "rent_type": None,

--- a/leasing/report/lease/rent_type.py
+++ b/leasing/report/lease/rent_type.py
@@ -8,15 +8,12 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import ContactType, RentType, TenantContactType
 from leasing.models import Rent, ServiceUnit
+from leasing.report.lease.common_getters import get_lease_ids_from_related_object
 from leasing.report.report_base import ReportBase
 
 
 class RentWithContactNames(Protocol):
     contact_names: str
-
-
-def get_lease_id(obj: Rent):
-    return obj.lease.get_identifier_string()
 
 
 def get_tenants(obj: RentWithContactNames) -> str:
@@ -89,7 +86,10 @@ class RentTypeReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"source": get_lease_id, "label": _("Lease id")},
+        "lease_ids": {
+            "source": get_lease_ids_from_related_object,
+            "label": _("Lease id"),
+        },
         "tenant_name": {
             "source": get_tenants,
             "label": _("Tenant name"),

--- a/leasing/report/lease/rent_type.py
+++ b/leasing/report/lease/rent_type.py
@@ -86,7 +86,7 @@ class RentTypeReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },

--- a/leasing/report/lease/rent_type.py
+++ b/leasing/report/lease/rent_type.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import ContactType, RentType, TenantContactType
 from leasing.models import Rent, ServiceUnit
-from leasing.report.lease.common_getters import get_lease_ids_from_related_object
+from leasing.report.lease.common_getters import get_lease_link_data_from_related_object
 from leasing.report.report_base import ReportBase
 
 
@@ -86,8 +86,8 @@ class RentTypeReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {
-            "source": get_lease_ids_from_related_object,
+        "lease_link_data": {
+            "source": get_lease_link_data_from_related_object,
             "label": _("Lease id"),
         },
         "tenant_name": {

--- a/leasing/report/lease/reservations.py
+++ b/leasing/report/lease/reservations.py
@@ -8,11 +8,8 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import ContactType, LeaseState, TenantContactType
 from leasing.models import Lease, ServiceUnit
+from leasing.report.lease.common_getters import get_lease_ids
 from leasing.report.report_base import ReportBase
-
-
-def get_lease_id(lease):
-    return lease.get_identifier_string()
 
 
 def get_area(lease):
@@ -173,7 +170,7 @@ class ReservationsReport(ReportBase):
         ),
     }
     output_fields = {
-        "reservation_id": {"source": get_lease_id, "label": _("Reservation id")},
+        "lease_id": {"source": get_lease_ids, "label": _("Reservation id")},
         "area": {"source": get_area, "label": _("Lease area"), "width": 30},
         "address": {"source": get_address, "label": _("Address"), "width": 50},
         "reservee_name": {

--- a/leasing/report/lease/reservations.py
+++ b/leasing/report/lease/reservations.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from leasing.enums import ContactType, LeaseState, TenantContactType
 from leasing.models import Lease, ServiceUnit
-from leasing.report.lease.common_getters import get_lease_ids
+from leasing.report.lease.common_getters import get_lease_link_data
 from leasing.report.report_base import ReportBase
 
 
@@ -170,7 +170,10 @@ class ReservationsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_ids": {"source": get_lease_ids, "label": _("Reservation id")},
+        "lease_link_data": {
+            "source": get_lease_link_data,
+            "label": _("Reservation id"),
+        },
         "area": {"source": get_area, "label": _("Lease area"), "width": 30},
         "address": {"source": get_address, "label": _("Address"), "width": 50},
         "reservee_name": {

--- a/leasing/report/lease/reservations.py
+++ b/leasing/report/lease/reservations.py
@@ -170,7 +170,7 @@ class ReservationsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_id": {"source": get_lease_ids, "label": _("Reservation id")},
+        "lease_ids": {"source": get_lease_ids, "label": _("Reservation id")},
         "area": {"source": get_area, "label": _("Lease area"), "width": 30},
         "address": {"source": get_address, "label": _("Address"), "width": 50},
         "reservee_name": {

--- a/leasing/report/lease/reservations.py
+++ b/leasing/report/lease/reservations.py
@@ -170,7 +170,7 @@ class ReservationsReport(ReportBase):
         ),
     }
     output_fields = {
-        "lease_link_data": {
+        "lease_identifier": {
             "source": get_lease_link_data,
             "label": _("Reservation id"),
         },

--- a/leasing/report/report_base.py
+++ b/leasing/report/report_base.py
@@ -19,6 +19,9 @@ from rest_framework.response import Response
 
 from leasing.report.excel import ExcelRow, FormatType
 from leasing.report.forms import ReportFormBase
+from leasing.report.lease.common_getters import (
+    get_identifier_string_from_lease_link_data,
+)
 from leasing.report.serializers import ReportOutputSerializer
 
 
@@ -245,6 +248,9 @@ class ReportBase:
         first_data_row_num = row_num
         for row in data:
             if isinstance(row, dict):
+                row["lease_identifier"] = get_identifier_string_from_lease_link_data(
+                    row
+                )
                 self.write_dict_row_to_worksheet(worksheet, formats, row_num, row)
             elif isinstance(row, ExcelRow):
                 for cell in row.cells:

--- a/leasing/report/utils.py
+++ b/leasing/report/utils.py
@@ -17,9 +17,10 @@ class InvoicingGapsRow(TypedDict):
     recipient_name: str
 
 
-class InvoicingReviewReportOutput(TypedDict):
+class InvoicingReviewReportRow(TypedDict):
     section: str | None
     lease_identifier: str | None
+    lease_id: int | None
     start_date: date | None
     end_date: date | None
     note: str | None

--- a/leasing/report/utils.py
+++ b/leasing/report/utils.py
@@ -17,6 +17,14 @@ class InvoicingGapsRow(TypedDict):
     recipient_name: str
 
 
+class InvoicingDisabledReportRow(TypedDict):
+    section: None
+    lease_identifier: str | None
+    lease_id: int | None
+    start_date: date | None
+    end_date: date | None
+
+
 class InvoicingReviewReportRow(TypedDict):
     section: str | None
     lease_identifier: str | None

--- a/leasing/tests/test_common_getters.py
+++ b/leasing/tests/test_common_getters.py
@@ -1,0 +1,41 @@
+# test common_getters related to lease_link data
+
+import pytest
+
+from leasing.report.lease.common_getters import (
+    get_identifier_string_from_lease_link_data,
+    get_lease_link_data,
+    get_lease_link_data_from_related_object,
+)
+
+
+@pytest.mark.django_db
+def test_get_lease_link_data_from_related_object(contract_factory, lease_factory):
+    lease = lease_factory()
+    contract = contract_factory(lease=lease, type_id=1)
+
+    lease_link_data = get_lease_link_data_from_related_object(contract)
+
+    assert lease_link_data["id"] == lease.id
+    assert lease_link_data["identifier"] == lease.get_identifier_string()
+
+    contract_without_lease = contract_factory(lease=None, type_id=1)
+    lease_link_data = get_lease_link_data_from_related_object(contract_without_lease)
+    assert lease_link_data["id"] is None
+    assert lease_link_data["identifier"] is None
+
+
+# test get_identifier_string_from_lease_link_data
+@pytest.mark.django_db
+def test_get_identifier_string_from_lease_link_data(lease_factory):
+    lease = lease_factory()
+    lease_link_data = get_lease_link_data(lease)
+
+    row = {"lease_identifier": lease_link_data}
+
+    assert (
+        get_identifier_string_from_lease_link_data(row) == lease.get_identifier_string()
+    )
+
+    row = {"lease_identifier": {"id": None, "identifier": None}}
+    assert get_identifier_string_from_lease_link_data(row) == "-"


### PR DESCRIPTION
This change does the following:

- `lease_id` / `lease_identifier` is now just `lease_identifier`, returning both the numerical `id` as well as the `identifier` string for the link. In the UI reports, it is rendered as a hyperlink to the lease, and on the Excel report, it is the lease identifier string.
- refactor the way the lease ids are resolved, making a more extensive usage of re-usable functions from the `common_getters`
- add a couple of tests to the new `common_getters`

Related frontend changes: https://github.com/City-of-Helsinki/mvj-ui/pull/576