### PR TITLE
statistic report: show contract numbers for contracts without signing date

### DIFF
--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -123,11 +123,7 @@ def get_latest_contract_number(lease: LeaseWithContracts):
         default=None,
     )
 
-    if (
-        latest_contract is None
-        or not latest_contract.signing_date
-        or not latest_contract.contract_number
-    ):
+    if latest_contract is None or not latest_contract.contract_number:
         return ""
 
     return latest_contract.contract_number


### PR DESCRIPTION
Show the contract number for latest contract of the lease in statistic report even in cases when the contract is not signed.