### PR TITLE
add .eml to allowed files

### DIFF
--- a/file_operations/tests/test_mixins.py
+++ b/file_operations/tests/test_mixins.py
@@ -31,6 +31,8 @@ def test_get_allowed_extensions(mixin):
         "fodt",
         "ods",
         "fods",
+        # Outlook
+        "eml",
     ]
     image_types = [
         "jpg",

--- a/file_operations/viewsets/mixins.py
+++ b/file_operations/viewsets/mixins.py
@@ -195,6 +195,8 @@ class FileExtensionFileMixin:
             "fodt",
             "ods",
             "fods",
+            # Outlook
+            "eml",
         ]
         image_types = [
             "jpg",


### PR DESCRIPTION
not restricted in mvj-ui anyway, but making this explicit this format is allowed. ui-public list does not allow this, and that seems fine. So essentially this doesn't "really" change anything, except that backend would allow this if front-end did also allow it.