### PR TITLE
Mvj 669 lease area export fix

### DIFF
--- a/leasing/admin.py
+++ b/leasing/admin.py
@@ -796,8 +796,6 @@ class VipunenMapLayerAdmin(FieldPermissionsModelAdmin):
         "color_display",
         "parent",
         "name_fi",
-        "name_sv",
-        "name_en",
         "keywords",
     )
     list_filter = ("parent",)
@@ -810,7 +808,7 @@ class VipunenMapLayerAdmin(FieldPermissionsModelAdmin):
         qs = super().get_queryset(request).order_by("parent")
         return qs.select_related("parent")
 
-    hierarchical_name.short_description = "Name"
+    hierarchical_name.short_description = "Hierarchical name"
 
     def color_display(self, obj: VipunenMapLayer):
         """Displays `hex_color` as a square."""

--- a/leasing/admin.py
+++ b/leasing/admin.py
@@ -800,6 +800,7 @@ class VipunenMapLayerAdmin(FieldPermissionsModelAdmin):
     )
     list_filter = ("parent",)
     search_fields = ["name_fi", "name_sv", "name_en", "keywords"]
+    autocomplete_fields = ["filter_by_lease_type", "filter_by_intended_use"]
 
     def hierarchical_name(self, obj: VipunenMapLayer):
         return str(obj)


### PR DESCRIPTION
changes the approach of finding matching maplayers for leasearea.
this approach is not efficient as for each LeaseArea it has to go through all MapLayers.
If this turns out to cause performance problems (too many queries), it could be further optimized by e.g. annotating results on the base queryset. it is a bit complex implementation so lets first test that this approach works as users want it to work.