### PR TITLE
MVJ-778 fix subvented initial year rent

### DIFF
--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -1763,20 +1763,22 @@ class LeaseBasisOfRent(ArchivableModel, TimeStampedSafeDeleteModel):
 
         if self.subvention_type == SubventionType.FORM_OF_MANAGEMENT:
             management_subventions = self.management_subventions.all()
-            if management_subventions:
-                total_subvention_amount = Decimal(0)
-                for management_subvention in management_subventions:
-                    total_subvention_amount += management_subvention.subvention_amount
+            if not management_subventions:
+                return round(initial_year_rent, 2)
 
-                amount_per_area = self.get_index_adjusted_amount_per_area()
+            total_subvention_amount = Decimal(0)
+            for management_subvention in management_subventions:
+                total_subvention_amount += management_subvention.subvention_amount
 
-                subvention_percent = round(
-                    (1 - (total_subvention_amount / amount_per_area)) * 100, 2
-                )
+            amount_per_area = self.get_index_adjusted_amount_per_area()
 
-                discount_multiplier = (100 - subvention_percent) / 100
+            subvention_percent = round(
+                (1 - (total_subvention_amount / amount_per_area)) * 100, 2
+            )
 
-                return round(initial_year_rent, 2) * discount_multiplier
+            discount_multiplier = (100 - subvention_percent) / 100
+
+            return round(initial_year_rent, 2) * discount_multiplier
 
         if self.subvention_type == SubventionType.RE_LEASE:
             subvention_percent = self.get_re_lease_subvention_percent()

--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -1778,7 +1778,6 @@ class LeaseBasisOfRent(ArchivableModel, TimeStampedSafeDeleteModel):
 
                 return round(initial_year_rent, 2) * discount_multiplier
 
-        # TODO: Find test cases for testing re-lease subvention
         if self.subvention_type == SubventionType.RE_LEASE:
             subvention_percent = self.get_re_lease_subvention_percent()
             return initial_year_rent * (1 - subvention_percent / 100)

--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -1726,12 +1726,18 @@ class LeaseBasisOfRent(ArchivableModel, TimeStampedSafeDeleteModel):
         return self.amount_per_area * index_ratio
 
     def get_re_lease_subvention_percent(self):
-        subvention_base_percent = self.subvention_base_percent | 0
-        subvention_graduated_percent = self.subvention_graduated_percent | 0
+        subvention_base_percent = (
+            self.subvention_base_percent if self.subvention_base_percent else 0
+        )
+        subvention_graduated_percent = (
+            self.subvention_graduated_percent
+            if self.subvention_graduated_percent
+            else 0
+        )
         percent = (
             1
-            - (1 - subvention_base_percent / 100)
-            * (1 - subvention_graduated_percent / 100)
+            - Decimal(1 - subvention_base_percent / 100)
+            * Decimal(1 - subvention_graduated_percent / 100)
         ) * 100
         return percent
 

--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -1727,11 +1727,13 @@ class LeaseBasisOfRent(ArchivableModel, TimeStampedSafeDeleteModel):
 
     def get_re_lease_subvention_percent(self):
         subvention_base_percent = (
-            self.subvention_base_percent if self.subvention_base_percent else 0
+            self.subvention_base_percent
+            if self.subvention_base_percent is not None
+            else 0
         )
         subvention_graduated_percent = (
             self.subvention_graduated_percent
-            if self.subvention_graduated_percent
+            if self.subvention_graduated_percent is not None
             else 0
         )
         percent = (

--- a/leasing/tests/conftest.py
+++ b/leasing/tests/conftest.py
@@ -252,12 +252,6 @@ class UiDataFactory(factory.django.DjangoModelFactory):
 
 
 @register
-class LeaseBasisOfRentFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = LeaseBasisOfRent
-
-
-@register
 class LeaseBasisOfRentManagementSubventionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = LeaseBasisOfRentManagementSubvention
@@ -406,6 +400,14 @@ class IntendedUseFactory(factory.django.DjangoModelFactory):
 class RentIntendedUseFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = RentIntendedUse
+
+
+@register
+class LeaseBasisOfRentFactory(factory.django.DjangoModelFactory):
+    intended_use = factory.SubFactory(RentIntendedUseFactory)
+
+    class Meta:
+        model = LeaseBasisOfRent
 
 
 @register

--- a/leasing/tests/conftest.py
+++ b/leasing/tests/conftest.py
@@ -69,7 +69,9 @@ from leasing.models.land_use_agreement import (
 from leasing.models.map_layers import VipunenMapLayer
 from leasing.models.receivable_type import ReceivableType
 from leasing.models.rent import (
+    Index,
     IndexPointFigureYearly,
+    LeaseBasisOfRentManagementSubvention,
     OldDwellingsInHousingCompaniesPriceIndex,
 )
 from leasing.models.service_unit import ServiceUnitGroupMapping
@@ -107,6 +109,12 @@ class AreaFactory(factory.django.DjangoModelFactory):
 class AreaSourceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = AreaSource
+
+
+@register
+class IndexFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Index
 
 
 @register
@@ -247,6 +255,12 @@ class UiDataFactory(factory.django.DjangoModelFactory):
 class LeaseBasisOfRentFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = LeaseBasisOfRent
+
+
+@register
+class LeaseBasisOfRentManagementSubventionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = LeaseBasisOfRentManagementSubvention
 
 
 @register

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -39,3 +39,35 @@ def test_calculate_subvented_initial_year_rent(
     assert round(
         lease_basis_of_rent.calculate_subvented_initial_year_rent(), 2
     ) == round(expected_subvented_initial_year_rent, 2)
+
+
+@pytest.mark.django_db
+def test_calculate_subvented_initial_year_rent_re_lease(
+    index_factory,
+    lease_basis_of_rent_factory,
+    lease_factory,
+):
+    index = index_factory(
+        number=2161,
+        year=2022,
+    )
+    lease_basis_of_rent = lease_basis_of_rent_factory(
+        lease=lease_factory(),
+        intended_use_id=1,
+        type="lease",
+        index=index,
+        area=Decimal(17987.00),
+        area_unit="kem2",
+        amount_per_area=Decimal(49.00),
+        profit_margin_percentage=Decimal(5.00),
+        discount_percentage=Decimal(27.800000),
+        subvention_type="re_lease",
+        subvention_base_percent=Decimal(5.00),
+        subvention_graduated_percent=Decimal(5.00),
+    )
+
+    expected_subvented_initial_year_rent = Decimal(859462.23)
+
+    assert round(
+        lease_basis_of_rent.calculate_subvented_initial_year_rent(), 2
+    ) == round(expected_subvented_initial_year_rent, 2)

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -19,7 +19,6 @@ def test_calculate_subvented_initial_year_rent_form_of_management(
     )
     lease_basis_of_rent = lease_basis_of_rent_factory(
         lease=lease_factory(),
-        intended_use_id=1,
         index=index,
         type=BasisOfRentType.LEASE,
         area=Decimal(2803.00),
@@ -54,7 +53,6 @@ def test_calculate_subvented_initial_year_rent_re_lease(
     )
     lease_basis_of_rent = lease_basis_of_rent_factory(
         lease=lease_factory(),
-        intended_use_id=1,
         type=BasisOfRentType.LEASE,
         index=index,
         area=Decimal(17987.00),

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -61,6 +61,28 @@ def test_calculate_subvented_initial_year_rent_re_lease(
         number=2161,
         year=2022,
     )
+
+    # If there are no subventions, the subvented initial year rent
+    # should be the same as the initial year rent
+    lease_basis_of_rent_without_subvention = lease_basis_of_rent_factory(
+        lease=lease_factory(),
+        type=BasisOfRentType.LEASE,
+        index=index,
+        area=Decimal(17987.00),
+        area_unit=AreaUnit.FLOOR_SQUARE_METRE,
+        amount_per_area=Decimal(49.00),
+        profit_margin_percentage=Decimal(5.00),
+        discount_percentage=Decimal(27.800000),
+    )
+
+    assert round(
+        lease_basis_of_rent_without_subvention.calculate_subvented_initial_year_rent(),
+        2,
+    ) == round(lease_basis_of_rent_without_subvention.calculate_initial_year_rent(), 2)
+
+    # In the case when there is a re-lease subvention,
+    # expect a certain number subvented initial year rent
+    # with the accuracy of two decimals
     lease_basis_of_rent = lease_basis_of_rent_factory(
         lease=lease_factory(),
         type=BasisOfRentType.LEASE,

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.mark.django_db
-def test_calculate_subvented_initial_year_rent(
+def test_calculate_subvented_initial_year_rent_form_of_management(
     index_factory,
     lease_basis_of_rent_factory,
     lease_basis_of_rent_management_subvention_factory,
@@ -19,6 +19,7 @@ def test_calculate_subvented_initial_year_rent(
         lease=lease_factory(),
         intended_use_id=1,
         index=index,
+        type="lease",
         area=Decimal(2803.00),
         area_unit="kem2",
         amount_per_area=Decimal(37.00),

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 
 import pytest
 
+from leasing.enums import AreaUnit, BasisOfRentType, SubventionType
+
 
 @pytest.mark.django_db
 def test_calculate_subvented_initial_year_rent_form_of_management(
@@ -19,13 +21,13 @@ def test_calculate_subvented_initial_year_rent_form_of_management(
         lease=lease_factory(),
         intended_use_id=1,
         index=index,
-        type="lease",
+        type=BasisOfRentType.LEASE,
         area=Decimal(2803.00),
-        area_unit="kem2",
+        area_unit=AreaUnit.FLOOR_SQUARE_METRE,
         amount_per_area=Decimal(37.00),
         profit_margin_percentage=Decimal(4.00),
         discount_percentage=Decimal(37.000000),
-        subvention_type="form_of_management",
+        subvention_type=SubventionType.FORM_OF_MANAGEMENT,
     )
     lease_basis_of_rent_management_subvention = (  # noqa: F841
         lease_basis_of_rent_management_subvention_factory(
@@ -55,14 +57,14 @@ def test_calculate_subvented_initial_year_rent_re_lease(
     lease_basis_of_rent = lease_basis_of_rent_factory(
         lease=lease_factory(),
         intended_use_id=1,
-        type="lease",
+        type=BasisOfRentType.LEASE,
         index=index,
         area=Decimal(17987.00),
-        area_unit="kem2",
+        area_unit=AreaUnit.FLOOR_SQUARE_METRE,
         amount_per_area=Decimal(49.00),
         profit_margin_percentage=Decimal(5.00),
         discount_percentage=Decimal(27.800000),
-        subvention_type="re_lease",
+        subvention_type=SubventionType.RE_LEASE,
         subvention_base_percent=Decimal(5.00),
         subvention_graduated_percent=Decimal(5.00),
     )

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -28,6 +28,16 @@ def test_calculate_subvented_initial_year_rent_form_of_management(
         discount_percentage=Decimal(37.000000),
         subvention_type=SubventionType.FORM_OF_MANAGEMENT,
     )
+
+    # If there are no management subventions, the subvented initial year rent
+    # should be the same as the initial year rent
+    assert round(
+        lease_basis_of_rent.calculate_subvented_initial_year_rent(), 2
+    ) == round(lease_basis_of_rent.calculate_initial_year_rent(), 2)
+
+    # In the case when there is a management subvention,
+    # expect a certain number subvented initial year rent
+    # with the accuracy of two decimals
     lease_basis_of_rent_management_subvention_factory(
         lease_basis_of_rent=lease_basis_of_rent,
         subvention_amount=516.45,

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -1,0 +1,41 @@
+from decimal import Decimal
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_calculate_subvented_initial_year_rent(
+    index_factory,
+    lease_basis_of_rent_factory,
+    lease_basis_of_rent_management_subvention_factory,
+    lease_factory,
+):
+    index = index_factory(
+        number=1994,
+        year=2021,
+        month=2,
+    )
+    lease_basis_of_rent = lease_basis_of_rent_factory(
+        lease=lease_factory(),
+        intended_use_id=1,
+        index=index,
+        area=Decimal(2803.00),
+        area_unit="kem2",
+        amount_per_area=Decimal(37.00),
+        profit_margin_percentage=Decimal(4.00),
+        discount_percentage=Decimal(37.000000),
+        subvention_type="form_of_management",
+    )
+    lease_basis_of_rent_management_subvention = (  # noqa: F841
+        lease_basis_of_rent_management_subvention_factory(
+            lease_basis_of_rent=lease_basis_of_rent,
+            subvention_amount=516.45,
+            management_id=1,
+        )
+    )
+
+    expected_subvented_initial_year_rent = Decimal(57903.92)
+
+    assert round(
+        lease_basis_of_rent.calculate_subvented_initial_year_rent(), 2
+    ) == round(expected_subvented_initial_year_rent, 2)

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -29,12 +29,10 @@ def test_calculate_subvented_initial_year_rent_form_of_management(
         discount_percentage=Decimal(37.000000),
         subvention_type=SubventionType.FORM_OF_MANAGEMENT,
     )
-    lease_basis_of_rent_management_subvention = (  # noqa: F841
-        lease_basis_of_rent_management_subvention_factory(
-            lease_basis_of_rent=lease_basis_of_rent,
-            subvention_amount=516.45,
-            management_id=1,
-        )
+    lease_basis_of_rent_management_subvention_factory(
+        lease_basis_of_rent=lease_basis_of_rent,
+        subvention_amount=516.45,
+        management_id=1,
     )
 
     expected_subvented_initial_year_rent = Decimal(57903.92)


### PR DESCRIPTION
Fix the following issues with `Subventoitu alkuvuosivuokra (ind)` field on the statistic report:
- The field becomes 0 when the initial year rent and subvented initial year rent are equal.
- The field shows inaccurate values due to rounding.