### PR TITLE
statistic report: fixes for initial year rent

### DIFF
--- a/leasing/models/rent.py
+++ b/leasing/models/rent.py
@@ -1744,19 +1744,19 @@ class LeaseBasisOfRent(ArchivableModel, TimeStampedSafeDeleteModel):
         return percent
 
     def calculate_initial_year_rent(self):
-        if not self.area or not self.amount_per_area:
+        if (
+            not self.area
+            or not self.amount_per_area
+            or not self.profit_margin_percentage
+        ):
             return Decimal(0)
 
-        base_rent = self.area * self.amount_per_area
-        if self.profit_margin_percentage:
-            base_rent *= self.profit_margin_percentage / 100
+        initial_year_rent = (
+            self.area * self.amount_per_area * self.profit_margin_percentage / 100
+        )
 
-        if self.index:
-            index_ratio = Decimal(self.index.number / 100)
-        else:
-            index_ratio = Decimal(1)
-
-        initial_year_rent = base_rent * index_ratio
+        if self.index and self.type != BasisOfRentType.LEASE2022:
+            initial_year_rent *= Decimal(self.index.number / 100)
 
         return initial_year_rent
 

--- a/leasing/tests/models/test_lease_basis_of_rent.py
+++ b/leasing/tests/models/test_lease_basis_of_rent.py
@@ -6,6 +6,70 @@ from leasing.enums import AreaUnit, BasisOfRentType, SubventionType
 
 
 @pytest.mark.django_db
+def test_calculate_initial_year_rent(
+    index_factory,
+    lease_basis_of_rent_factory,
+    lease_factory,
+):
+    index = index_factory(
+        number=1951,
+        year=2018,
+        month=8,
+    )
+    area = Decimal(12580.00)
+    amount_per_area = Decimal(29.00)
+    profit_margin_percentage = Decimal(5.00)
+
+    lease_basis_of_rent = lease_basis_of_rent_factory(
+        lease=lease_factory(),
+        type=BasisOfRentType.LEASE,
+        index=index,
+        area=Decimal(0.00),
+        area_unit=AreaUnit.FLOOR_SQUARE_METRE,
+        amount_per_area=Decimal(0.00),
+        profit_margin_percentage=Decimal(0.00),
+    )
+
+    # In the case when there is no area,
+    # initial year rent should be 0
+    lease_basis_of_rent.area = Decimal(0.00)
+    lease_basis_of_rent.amount_per_area = amount_per_area
+    lease_basis_of_rent.profit_margin_percentage = profit_margin_percentage
+
+    assert round(lease_basis_of_rent.calculate_initial_year_rent(), 2) == Decimal(0.00)
+
+    # In the case when there is no amount_per_area,
+    # initial year rent should be 0
+    lease_basis_of_rent.area = area
+    lease_basis_of_rent.amount_per_area = Decimal(0.00)
+    lease_basis_of_rent.profit_margin_percentage = profit_margin_percentage
+
+    assert round(lease_basis_of_rent.calculate_initial_year_rent(), 2) == Decimal(0.00)
+
+    # In the case when there is no profit_margin_percentage,
+    # initial year rent should be 0
+    lease_basis_of_rent.area = area
+    lease_basis_of_rent.amount_per_area = amount_per_area
+    lease_basis_of_rent.profit_margin_percentage = Decimal(0.00)
+
+    assert round(lease_basis_of_rent.calculate_initial_year_rent(), 2) == Decimal(0.00)
+
+    # In the case when
+    # area, amount_per_area and profit_margin_percentage
+    # are all defined and greater than 0,
+    # expect a certain number for initial year rent with the accuracy of two decimals
+    lease_basis_of_rent.area = area
+    lease_basis_of_rent.amount_per_area = amount_per_area
+    lease_basis_of_rent.profit_margin_percentage = profit_margin_percentage
+
+    expected_initial_year_rent = Decimal(355881.91)
+
+    assert round(lease_basis_of_rent.calculate_initial_year_rent(), 2) == round(
+        expected_initial_year_rent, 2
+    )
+
+
+@pytest.mark.django_db
 def test_calculate_subvented_initial_year_rent_form_of_management(
     index_factory,
     lease_basis_of_rent_factory,


### PR DESCRIPTION
The `Alkuvuosivuokra` (`initial_year_rent`) was calculated even when profit margin percentage was not set.

These changes implement:
- if the basis of rent's type is `LEASE2022`, do not apply index ratio to `initial_year_rent`. If not, apply it. 
- requirement that `area`, `amount_per_area` and `profit_margin_percentage` are all set in order to calculate `initial_year_rent`. If one of these is not set, the `initial_year_rent` should be 0.