### PR TITLE
MVJ-610 Command and batchrun job to populate missing tasotarkistus values in rent

### DIFF
--- a/leasing/fixtures/batchrun_command.json
+++ b/leasing/fixtures/batchrun_command.json
@@ -166,5 +166,17 @@
       "parameters": {},
       "parameter_format_string": ""
     }
+  },
+  {
+    "model": "batchrun.command",
+    "pk": 17,
+    "fields": {
+      "deleted": null,
+      "deleted_by_cascade": false,
+      "type": "django-manage",
+      "name": "update_missing_periodic_rent_adjustment_index_values",
+      "parameters": {},
+      "parameter_format_string": ""
+    }
   }
 ]

--- a/leasing/fixtures/batchrun_job.json
+++ b/leasing/fixtures/batchrun_job.json
@@ -202,11 +202,26 @@
     "fields": {
       "deleted": null,
       "deleted_by_cascade": false,
-      "created_at": "2024-09-16T08:00:00.000Z", 
+      "created_at": "2024-09-16T08:00:00.000Z",
       "modified_at": "2024-09-16T08:00:00.000Z",
       "name": "Tasotarkistuksen indeksien haku",
       "comment": "",
       "command": 14,
+      "arguments": {},
+      "history_retention_policy": 1
+    }
+  },
+  {
+    "model": "batchrun.job",
+    "pk": 17,
+    "fields": {
+      "deleted": null,
+      "deleted_by_cascade": false,
+      "created_at": "2025-03-21T08:00:00.000Z",
+      "modified_at": "2025-03-21T08:00:00.000Z",
+      "name": "Tasotarkistuksen puuttuvien indeksiarvojen päivittäminen vuokriin",
+      "comment": "",
+      "command": 17,
       "arguments": {},
       "history_retention_policy": 1
     }

--- a/leasing/fixtures/batchrun_scheduled_job.json
+++ b/leasing/fixtures/batchrun_scheduled_job.json
@@ -273,7 +273,7 @@
     "model": "batchrun.scheduledjob",
     "pk": 16,
     "fields": {
-      "created_at": "2024-09-16T08:00:00.000Z", 
+      "created_at": "2024-09-16T08:00:00.000Z",
       "modified_at": "2024-09-16T08:00:00.000Z",
       "job": 14,
       "comment": "Tasotarkistuksen indeksien haku",
@@ -284,6 +284,24 @@
       "days_of_month": "*",
       "weekdays": "*",
       "hours": "22",
+      "minutes": "00"
+    }
+  },
+  {
+    "model": "batchrun.scheduledjob",
+    "pk": 17,
+    "fields": {
+      "created_at": "2025-03-21T08:00:00.000Z",
+      "modified_at": "2025-03-21T08:00:00.000Z",
+      "job": 17,
+      "comment": "Nightly update of missing tasotarkistus values",
+      "enabled": false,
+      "timezone": 1,
+      "years": "*",
+      "months": "*",
+      "days_of_month": "*",
+      "weekdays": "*",
+      "hours": "23",
       "minutes": "00"
     }
   },

--- a/leasing/management/commands/import_periodic_rent_adjustment_index.py
+++ b/leasing/management/commands/import_periodic_rent_adjustment_index.py
@@ -1,6 +1,7 @@
 import datetime
 import json
-from typing import Callable, TypedDict
+from collections.abc import Callable
+from typing import TypedDict
 
 import requests
 from django.core.management.base import BaseCommand, CommandError

--- a/leasing/management/commands/update_missing_periodic_rent_adjustment_index_values.py
+++ b/leasing/management/commands/update_missing_periodic_rent_adjustment_index_values.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from leasing.models.rent import IndexPointFigureYearly, Rent
+
+
+class Command(BaseCommand):
+    help = (
+        "Update missing tasotarkistus values fields for Rent objects that were"
+        " created when the tasotarkistus values were not yet available."
+    )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        rents = Rent.objects.filter(
+            old_dwellings_in_housing_companies_price_index__isnull=False,
+            start_price_index_point_figure_value__isnull=True,
+            start_price_index_point_figure_year__isnull=True,
+        )
+        if not rents.exists():
+            self.stdout.write(
+                "No Rent objects with missing tasotarkistus values to update."
+            )
+            return
+
+        updated_count = 0
+
+        for rent in rents:
+            price_index = rent.old_dwellings_in_housing_companies_price_index
+            point_figure_year: int = rent.lease.start_date.year - 1
+
+            try:
+                point_figure = IndexPointFigureYearly.objects.get(
+                    index=price_index, year=point_figure_year
+                )
+                rent.start_price_index_point_figure_value = point_figure.value
+                rent.start_price_index_point_figure_year = point_figure.year
+                rent.save()
+                updated_count += 1
+                self.stdout.write(
+                    f"Updated Rent ID {rent.pk} with index value {point_figure.value} for year {point_figure.year}."
+                )
+            except IndexPointFigureYearly.DoesNotExist:
+                self.stdout.write(
+                    f"Rent ID {rent.pk}: IndexPointFigureYearly for year {point_figure_year} is not yet available."
+                )
+
+        self.stdout.write(f"Added point figure values to {updated_count} Rent objects.")
+        self.stdout.write("Done.")

--- a/leasing/tests/management/commands/test_update_missing_periodic_rent_adjustment_index_values.py
+++ b/leasing/tests/management/commands/test_update_missing_periodic_rent_adjustment_index_values.py
@@ -1,0 +1,111 @@
+from typing import Callable
+
+import pytest
+from _pytest.capture import CaptureFixture
+from django.core.management import call_command
+
+from leasing.models.rent import IndexPointFigureYearly, Rent
+
+
+@pytest.mark.django_db
+def test_no_rents_to_update(capfd: CaptureFixture[str]) -> None:
+    """
+    No Rent objects need updating.
+    """
+    call_command("update_missing_periodic_rent_adjustment_index_values")
+    captured = capfd.readouterr()
+    assert (
+        "No Rent objects with missing tasotarkistus values to update." in captured.out
+    )
+
+
+@pytest.mark.django_db
+def test_update_rent_with_existing_index_point_figure(
+    index_point_figure_yearly_factory: Callable[..., IndexPointFigureYearly],
+    lease_factory: Callable[..., Rent],
+    old_dwellings_in_housing_companies_price_index_factory: Callable[..., str],
+    rent_factory: Callable[..., Rent],
+) -> None:
+    """
+    Single rent object is successfully updated.
+    """
+    price_index = old_dwellings_in_housing_companies_price_index_factory()
+    lease = lease_factory(start_date="2025-01-01")
+    rent = rent_factory(
+        old_dwellings_in_housing_companies_price_index=price_index,
+        start_price_index_point_figure_value=None,
+        start_price_index_point_figure_year=None,
+        lease=lease,
+    )
+    index_point_figure_yearly_factory(index=price_index, year=2024, value=104)
+
+    call_command("update_missing_periodic_rent_adjustment_index_values")
+    rent.refresh_from_db()
+
+    assert rent.start_price_index_point_figure_value == 104
+    assert rent.start_price_index_point_figure_year == 2024
+
+
+@pytest.mark.django_db
+def test_missing_index_point_figure(
+    lease_factory: Callable[..., Rent],
+    old_dwellings_in_housing_companies_price_index_factory: Callable[..., str],
+    rent_factory: Callable[..., Rent],
+) -> None:
+    """
+    IndexPointFigureYearly does not exist for the required year so the rent's
+    values are not updated.
+    """
+    price_index = old_dwellings_in_housing_companies_price_index_factory()
+    lease = lease_factory(start_date="2025-01-01")
+    rent = rent_factory(
+        old_dwellings_in_housing_companies_price_index=price_index,
+        start_price_index_point_figure_value=None,
+        start_price_index_point_figure_year=None,
+        lease=lease,
+    )
+
+    call_command("update_missing_periodic_rent_adjustment_index_values")
+    rent.refresh_from_db()
+
+    assert rent.start_price_index_point_figure_value is None
+    assert rent.start_price_index_point_figure_year is None
+
+
+@pytest.mark.django_db
+def test_multiple_rents_updated(
+    index_point_figure_yearly_factory: Callable[..., IndexPointFigureYearly],
+    lease_factory: Callable[..., Rent],
+    old_dwellings_in_housing_companies_price_index_factory: Callable[..., str],
+    rent_factory: Callable[..., Rent],
+) -> None:
+    """
+    Multiple Rent objects are updated.
+    """
+    price_index = old_dwellings_in_housing_companies_price_index_factory()
+    lease1 = lease_factory(start_date="2024-01-01")
+    lease2 = lease_factory(start_date="2025-01-01")
+    rent1 = rent_factory(
+        old_dwellings_in_housing_companies_price_index=price_index,
+        start_price_index_point_figure_value=None,
+        start_price_index_point_figure_year=None,
+        lease=lease1,
+    )
+    rent2 = rent_factory(
+        old_dwellings_in_housing_companies_price_index=price_index,
+        start_price_index_point_figure_value=None,
+        start_price_index_point_figure_year=None,
+        lease=lease2,
+    )
+    index_point_figure_yearly_factory(index=price_index, year=2023, value=103)
+    index_point_figure_yearly_factory(index=price_index, year=2024, value=104)
+
+    call_command("update_missing_periodic_rent_adjustment_index_values")
+    rent1.refresh_from_db()
+    rent2.refresh_from_db()
+
+    assert rent1.start_price_index_point_figure_value == 103
+    assert rent1.start_price_index_point_figure_year == 2023
+
+    assert rent2.start_price_index_point_figure_value == 104
+    assert rent2.start_price_index_point_figure_year == 2024

--- a/leasing/tests/management/commands/test_update_missing_periodic_rent_adjustment_index_values.py
+++ b/leasing/tests/management/commands/test_update_missing_periodic_rent_adjustment_index_values.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from _pytest.capture import CaptureFixture

--- a/leasing/tests/management/commands/test_update_missing_periodic_rent_adjustment_index_values.py
+++ b/leasing/tests/management/commands/test_update_missing_periodic_rent_adjustment_index_values.py
@@ -4,6 +4,7 @@ import pytest
 from _pytest.capture import CaptureFixture
 from django.core.management import call_command
 
+from leasing.models.lease import Lease
 from leasing.models.rent import IndexPointFigureYearly, Rent
 
 
@@ -22,7 +23,7 @@ def test_no_rents_to_update(capfd: CaptureFixture[str]) -> None:
 @pytest.mark.django_db
 def test_update_rent_with_existing_index_point_figure(
     index_point_figure_yearly_factory: Callable[..., IndexPointFigureYearly],
-    lease_factory: Callable[..., Rent],
+    lease_factory: Callable[..., Lease],
     old_dwellings_in_housing_companies_price_index_factory: Callable[..., str],
     rent_factory: Callable[..., Rent],
 ) -> None:
@@ -48,7 +49,7 @@ def test_update_rent_with_existing_index_point_figure(
 
 @pytest.mark.django_db
 def test_missing_index_point_figure(
-    lease_factory: Callable[..., Rent],
+    lease_factory: Callable[..., Lease],
     old_dwellings_in_housing_companies_price_index_factory: Callable[..., str],
     rent_factory: Callable[..., Rent],
 ) -> None:
@@ -75,7 +76,7 @@ def test_missing_index_point_figure(
 @pytest.mark.django_db
 def test_multiple_rents_updated(
     index_point_figure_yearly_factory: Callable[..., IndexPointFigureYearly],
-    lease_factory: Callable[..., Rent],
+    lease_factory: Callable[..., Lease],
     old_dwellings_in_housing_companies_price_index_factory: Callable[..., str],
     rent_factory: Callable[..., Rent],
 ) -> None:


### PR DESCRIPTION
Updates rents that use tasotarkistus (`old_dwellings_in_housing_companies_price_index` is not null) but have empty fields for the point figure details (`start_price_index_point_figure_*`)

When deploying, remember to backup staging and production batchrun database tables into fixture, and enable all jobs that are intended to be enabled. Either by updating the `enabled=true` values into the fixture to be loaded, or afterwards in database.