### PR TITLE
fix permissions for relatedplotapplication

### DIFF
--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -880,7 +880,7 @@ DEFAULT_MODEL_PERMS = {
         6: ("view",),
         7: ("view", "add", "change", "delete"),
     },
-    "relatedplotapplications": {
+    "relatedplotapplication": {
         1: ("view",),
         2: ("view",),
         3: ("view",),


### PR DESCRIPTION
There was a typo in group model permissions for related plot applications. This fixes that issue.

This change is stand-alone, but also required for these changes: https://github.com/City-of-Helsinki/mvj-ui/pull/598