### PR TITLE
MVJ-726 Area search officer email updates

### DIFF
--- a/forms/tests/conftest.py
+++ b/forms/tests/conftest.py
@@ -10,6 +10,9 @@ from faker import Faker
 
 from forms.models import Answer
 from plotsearch.models.plot_search import AreaSearch
+from plotsearch.tests.conftest import (  # noqa:F401
+    setup_lessor_contacts_and_service_units,
+)
 from utils.email import EmailMessageInput
 
 fake = Faker("fi_FI")

--- a/forms/tests/test_utils.py
+++ b/forms/tests/test_utils.py
@@ -23,60 +23,10 @@ from forms.utils import (
     clone_object,
     generate_and_queue_answer_emails,
 )
-from plotsearch.enums import AreaSearchLessor
 from utils.email import EmailMessageInput, send_email
 
 BASIC_TEMPLATE_SECTION_COUNT = 7
 BASIC_TEMPLATE_FIELD_COUNT = 23
-
-
-@pytest.fixture
-def setup_lessor_contacts_and_service_units(service_unit_factory, contact_factory):
-    """
-    Sets up lessor contacts and service units for testing.
-    Should be used in all tests that call generate_and_queue_answer_emails.
-
-    Normally, service units have specific known IDs, but during testing they are
-    initialized with factories, so we need to align some logic to these dynamic
-    IDs.
-    """
-    from leasing.enums import ServiceUnitId
-    from leasing.models.contact import Contact
-    from leasing.models.service_unit import ServiceUnit
-
-    # Assumption: all service units are also area search lessors
-    assert len(ServiceUnitId) == len(AreaSearchLessor)
-
-    service_units: list[ServiceUnit] = []
-    contacts: list[Contact] = []
-
-    # Instantiate service units and lessor contacts via factories
-    for unit_id in ServiceUnitId:
-        unit = service_unit_factory(name=str(unit_id))
-        service_units.append(unit)
-        contacts.append(
-            contact_factory(
-                name=unit.name,
-                service_unit=unit,
-                is_lessor=True,
-                email=f"{unit_id.name}@example.com",
-            )
-        )
-
-    def mock_map_lessor_enum_to_service_unit_id(lessor: AreaSearchLessor) -> int:
-        """Maps an areasearch lessor to a service unit ID that was created in this fixture via a factory."""
-        lessors_enum_list = list(AreaSearchLessor)
-        mock_map = {
-            lessor: service_units[i].pk for i, lessor in enumerate(lessors_enum_list)
-        }
-        return mock_map[lessor]
-
-    # Apply the mock to all tests that use this fixture
-    with patch(
-        "plotsearch.utils.map_lessor_enum_to_service_unit_id",
-        side_effect=mock_map_lessor_enum_to_service_unit_id,
-    ):
-        yield
 
 
 @pytest.mark.django_db

--- a/plotsearch/models/plot_search.py
+++ b/plotsearch/models/plot_search.py
@@ -207,7 +207,8 @@ class PlotSearchTarget(models.Model):
         "targetstatus",
         "favouritetarget",
         "directreservationlink_targets",
-        "targetinfolink" "lease",
+        "targetinfolink",
+        "lease",
         "planunit",
         "customdetailedplan",
     ]

--- a/plotsearch/tests/conftest.py
+++ b/plotsearch/tests/conftest.py
@@ -1,10 +1,15 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
 from django.test import override_settings
 
+from leasing.enums import ServiceUnitId
+from leasing.models.contact import Contact
+from leasing.models.service_unit import ServiceUnit
 from mvj.tests.test_urls import reload_urlconf
+from plotsearch.enums import AreaSearchLessor
 
 
 @pytest.fixture(scope="package", autouse=True)
@@ -36,3 +41,51 @@ def django_db_setup(django_db_setup, django_db_blocker):
 
     with django_db_blocker.unblock():
         call_command("loaddata", *fixture_filenames)
+
+
+@pytest.fixture
+def setup_lessor_contacts_and_service_units(service_unit_factory, contact_factory):
+    """
+    Sets up lessor contacts and service units for testing.
+    Should be used in all tests that call generate_and_queue_answer_emails.
+
+    Normally, service units have specific known IDs, but during testing they are
+    initialized with factories, so we need to align some logic to these dynamic
+    IDs.
+    """
+    # Assumption: all service units are also area search lessors
+    assert len(ServiceUnitId) == len(AreaSearchLessor)
+
+    service_units: list[ServiceUnit] = []
+    contacts: list[Contact] = []
+
+    # Instantiate service units and lessor contacts via factories
+    for unit_id in ServiceUnitId:
+        unit = service_unit_factory(name=str(unit_id))
+        service_units.append(unit)
+        contacts.append(
+            contact_factory(
+                name=unit.name,
+                service_unit=unit,
+                is_lessor=True,
+                email=f"{unit_id.name}@example.com",
+            )
+        )
+
+    lessors_enum_list = list(AreaSearchLessor)
+    mock_map = {
+        lessor: service_units[i].pk for i, lessor in enumerate(lessors_enum_list)
+    }
+
+    def mock_map_lessor_enum_to_service_unit_id(lessor: AreaSearchLessor) -> int:
+        """Maps an areasearch lessor to a service unit ID that was created via a factory."""
+        return mock_map[lessor]
+
+    with patch(
+        "plotsearch.utils.map_lessor_enum_to_service_unit_id",
+        side_effect=mock_map_lessor_enum_to_service_unit_id,
+    ), patch(
+        "plotsearch.tests.test_utils.map_lessor_enum_to_service_unit_id",
+        side_effect=mock_map_lessor_enum_to_service_unit_id,
+    ):
+        yield

--- a/plotsearch/tests/test_utils.py
+++ b/plotsearch/tests/test_utils.py
@@ -1,8 +1,5 @@
-from unittest.mock import patch
-
 import pytest
 
-from leasing.enums import ServiceUnitId
 from leasing.models.contact import Contact
 from leasing.models.service_unit import ServiceUnit
 from plotsearch.enums import AreaSearchLessor
@@ -11,53 +8,6 @@ from plotsearch.utils import (
     map_intended_use_to_service_unit_id,
     map_lessor_enum_to_service_unit_id,
 )
-
-
-@pytest.fixture
-def setup_lessor_contacts_and_service_units(service_unit_factory, contact_factory):
-    """
-    Sets up lessor contacts and service units for testing.
-    Should be used in all tests that call generate_and_queue_answer_emails.
-
-    Normally, service units have specific known IDs, but during testing they are
-    initialized with factories, so we need to align some logic to these dynamic
-    IDs.
-    """
-    # Assumption: all service units are also area search lessors
-    assert len(ServiceUnitId) == len(AreaSearchLessor)
-
-    service_units: list[ServiceUnit] = []
-    contacts: list[Contact] = []
-
-    # Instantiate service units and lessor contacts via factories
-    for unit_id in ServiceUnitId:
-        unit = service_unit_factory(name=str(unit_id))
-        service_units.append(unit)
-        contacts.append(
-            contact_factory(
-                name=unit.name,
-                service_unit=unit,
-                is_lessor=True,
-                email=f"{unit_id.name}@example.com",
-            )
-        )
-
-    def mock_map_lessor_enum_to_service_unit_id(lessor: AreaSearchLessor) -> int:
-        """Maps an areasearch lessor to a service unit ID that was created via a factory."""
-        lessors_enum_list = list(AreaSearchLessor)
-        mock_map = {
-            lessor: service_units[i].pk for i, lessor in enumerate(lessors_enum_list)
-        }
-        return mock_map[lessor]
-
-    with patch(
-        "plotsearch.utils.map_lessor_enum_to_service_unit_id",
-        side_effect=mock_map_lessor_enum_to_service_unit_id,
-    ), patch(
-        "plotsearch.tests.test_utils.map_lessor_enum_to_service_unit_id",
-        side_effect=mock_map_lessor_enum_to_service_unit_id,
-    ):
-        yield
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This updated subject and body was suggested by a service unit, and approved by others in project group. Email subject requires such many details, because they have an extensive filtering setup based on the subject.

Emails are sent to officers when areasearch is A) created and B) updated with new lessor.