### PR TITLE
Revert "Disable an IntendedUse deletion migration"

### DIFF
--- a/leasing/migrations/0099_delete_inactive_intended_uses.py
+++ b/leasing/migrations/0099_delete_inactive_intended_uses.py
@@ -21,13 +21,8 @@ class Migration(migrations.Migration):
         ("leasing", "0098_alter_leasebasisofrent_subvention_graduated_percent"),
     ]
 
-    # Changed this migration to a no-op to avoid inadvertedly deleting valid
-    # data that might match the deletion criteria.
-    # Its purpose has been completed by the time this change is merged.
     operations = [
         migrations.RunPython(
-            # delete_inactive_intended_uses_with_service_unit_1,
-            migrations.RunPython.noop,
-            migrations.RunPython.noop,
+            delete_inactive_intended_uses_with_service_unit_1, migrations.RunPython.noop
         ),
     ]


### PR DESCRIPTION
This reverts commit 11de112067ce13595683939675edbfa4815ff709.

Need to re-enable the migration, because it was not yet performed in production by bringing develop-branch there.

This revert commit should be reverted after the intended uses have been deleted in production via this migration.