### PR TITLE
Reapply "Disable an IntendedUse deletion migration"

### DIFF
--- a/leasing/migrations/0099_delete_inactive_intended_uses.py
+++ b/leasing/migrations/0099_delete_inactive_intended_uses.py
@@ -21,8 +21,13 @@ class Migration(migrations.Migration):
         ("leasing", "0098_alter_leasebasisofrent_subvention_graduated_percent"),
     ]
 
+    # Changed this migration to a no-op to avoid inadvertedly deleting valid
+    # data that might match the deletion criteria.
+    # Its purpose has been completed by the time this change is merged.
     operations = [
         migrations.RunPython(
-            delete_inactive_intended_uses_with_service_unit_1, migrations.RunPython.noop
+            # delete_inactive_intended_uses_with_service_unit_1,
+            migrations.RunPython.noop,
+            migrations.RunPython.noop,
         ),
     ]


### PR DESCRIPTION
This reverts commit d654b670d0a560cfaca58686bb7df65e7c1ab3cd.

The migration has served its purpose in all environments now, and can be disabled to avoid possible corner case situations where intended uses would be unnecessarily deleted.