### PR TITLE
Mvj 843 rename areasearch form name field

### DIFF
--- a/forms/management/commands/generate_areasearch_form.py
+++ b/forms/management/commands/generate_areasearch_form.py
@@ -73,7 +73,7 @@ def initialize_area_search_form():
         label_en="Company name",
         label_sv="Företagsnamn",
         type="textbox",
-        identifier="yrityksen-nimi",
+        identifier="nimi",
         enabled=True,
         required=True,
         sort_order=0,


### PR DESCRIPTION
The current identifier of the name field in the area search application, company info section, is `yrityksen-nimi`. I changed it into just `nimi`, to harmonise it with the naming of the `Contact` model as well as the `laskunsaaja` section, and avoid ad hoc resolution of different names of the company name field.

EDIT: "The current label of the name field" => "The current identifier of the name field"