### PR TITLE
revert removing CustomAuditlogMiddleware

### DIFF
--- a/mvj/settings.py
+++ b/mvj/settings.py
@@ -229,7 +229,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "auditlog.middleware.AuditlogMiddleware",
+    "utils.middleware.CustomAuditlogMiddleware",
 ]
 
 TEMPLATES = [

--- a/utils/middleware.py
+++ b/utils/middleware.py
@@ -1,0 +1,15 @@
+from auditlog.context import set_actor
+from auditlog.middleware import AuditlogMiddleware
+from django.utils.functional import SimpleLazyObject
+
+
+class CustomAuditlogMiddleware(AuditlogMiddleware):
+    def __call__(self, request):
+        remote_addr = self._get_remote_addr(request)
+
+        user = SimpleLazyObject(lambda: getattr(request, "user", None))
+
+        context = set_actor(actor=user, remote_addr=remote_addr)
+
+        with context:
+            return self.get_response(request)


### PR DESCRIPTION
It is needed due to how DRF works in order to get the django-auditlog's actor (user) added to LogEntry