### PR TITLE
remove database check from init-migrate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,6 @@ WORKDIR /app
 
 COPY --chown=default:root requirements*.txt /app/
 
-USER root
-
-RUN dnf install -y \
-    nc \
-    && dnf clean all
-
 USER default
 
 RUN pip install --no-cache-dir -r /app/requirements.txt \

--- a/deploy/init-migrate.sh
+++ b/deploy/init-migrate.sh
@@ -2,16 +2,6 @@
 
 set -e
 
-if [ -z "$SKIP_DATABASE_CHECK" -o "$SKIP_DATABASE_CHECK" = "0" ]; then
-    until nc -z -v -w30 "$DATABASE_HOST" "$DATABASE_PORT"
-    do
-      echo "Waiting for postgres database connection..."
-      sleep 1
-    done
-    echo "Database is up!"
-fi
-
-
 # Apply database migrations
 if [[ "$APPLY_MIGRATIONS" = "1" ]]; then
     echo "Applying database migrations..."


### PR DESCRIPTION
also removes netcat as a dependency from Dockerfile

it was decided that this functionality is not needed for now, and it can be brought back if need arises