### PR TITLE
Don't preserve SFTP file timestamps

### DIFF
--- a/laske_export/management/commands/get_payments_from_laske.py
+++ b/laske_export/management/commands/get_payments_from_laske.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                 sftp.get_d(
                     settings.LASKE_SERVERS["payments"]["directory"],
                     get_import_dir(),
-                    preserve_mtime=True,
+                    preserve_mtime=False,
                 )
         except SSHException as e:
             logger.error(f"Error with the Laske payments server: {str(e)}")

--- a/laske_export/management/commands/get_payments_from_laske.py
+++ b/laske_export/management/commands/get_payments_from_laske.py
@@ -134,8 +134,10 @@ class Command(BaseCommand):
             "key_type" in settings.LASKE_SERVERS["payments"]
             and "key" in settings.LASKE_SERVERS["payments"]
         ):
+            logger.info("Key found, using SFTP")
             self.download_payments_sftp()
         else:
+            logger.info("No key found, using FTP")
             self.download_payments_ftp()
 
     def check_import_directory(self):
@@ -145,9 +147,11 @@ class Command(BaseCommand):
             )
             sys.exit(-1)
 
+        logger.info(f"Local target directory {get_import_dir()} found.")
         try:
             fp = tempfile.TemporaryFile(dir=get_import_dir())
             fp.close()
+            logger.info("Directory is writable, can proceed.")
         except PermissionError:
             logger.error(f'Can not create file in directory "{get_import_dir()}".')
             sys.exit(-1)


### PR DESCRIPTION
Modifying file timestamps is not permitted in the `azure-file` storage class that's used by MVJ API's shared openshift volume in Platta, where the SAP/Laske exports and imports are saved.

This change avoids the forbidden invocation of `os.utime()` in `pysftp.Connection.get()`