### PR TITLE
fix getting identifier from lease_link_data

### DIFF
--- a/leasing/report/lease/common_getters.py
+++ b/leasing/report/lease/common_getters.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Protocol, TypedDict
+from typing import Any, Protocol, TypedDict
 
 from django.db.models import QuerySet
 
@@ -55,11 +55,21 @@ def get_lease_link_data_from_related_object(
         }
 
 
-def get_identifier_string_from_lease_link_data(row: dict) -> str:
-    try:
-        return row["lease_identifier"]["identifier"] or "-"
-    except KeyError:
+def get_identifier_string_from_lease_link_data(
+    row: dict[str, Any],
+) -> str:
+    if not isinstance(row, dict):
         return "-"
+
+    lease_link_data = row.get("lease_identifier")
+    if isinstance(lease_link_data, str):
+        # Assuming this is already a lease_identifier string
+        return lease_link_data
+
+    if isinstance(lease_link_data, dict):
+        return lease_link_data.get("identifier") or "-"
+
+    return "-"
 
 
 def get_tenants(

--- a/leasing/tests/test_common_getters.py
+++ b/leasing/tests/test_common_getters.py
@@ -25,7 +25,6 @@ def test_get_lease_link_data_from_related_object(contract_factory, lease_factory
     assert lease_link_data["identifier"] is None
 
 
-# test get_identifier_string_from_lease_link_data
 @pytest.mark.django_db
 def test_get_identifier_string_from_lease_link_data(lease_factory):
     lease = lease_factory()
@@ -37,5 +36,19 @@ def test_get_identifier_string_from_lease_link_data(lease_factory):
         get_identifier_string_from_lease_link_data(row) == lease.get_identifier_string()
     )
 
-    row = {"lease_identifier": {"id": None, "identifier": None}}
-    assert get_identifier_string_from_lease_link_data(row) == "-"
+    non_lease_link_data_rows = [
+        None,
+        "123",
+        {"lease_identifier": {}},
+        {"lease_identifier": None},
+        {"lease_identifier": {"id": None, "identifier": None}},
+        {"lease_identifier": {"identifier": {}}},
+        {"lease_identifier": {"identifier": ""}},
+    ]
+    for row in non_lease_link_data_rows:
+        assert get_identifier_string_from_lease_link_data(row) == "-"
+
+    row = {"lease_identifier": lease.get_identifier_string()}
+    assert (
+        get_identifier_string_from_lease_link_data(row) == lease.get_identifier_string()
+    )


### PR DESCRIPTION
in a case where lease_identifier already existed in the report data as a key with value of the lease_identifier as string, get_identifier_string_from_lease_link_data() failed

the implementation nor the fix is optimal, but at this moment there is no reason to make a better fix