### PR TITLE
Only use SFTP if key and key_type have a value

### DIFF
--- a/laske_export/management/commands/get_payments_from_laske.py
+++ b/laske_export/management/commands/get_payments_from_laske.py
@@ -130,10 +130,10 @@ class Command(BaseCommand):
         ftp.quit()
 
     def download_payments(self):
-        if (
-            "key_type" in settings.LASKE_SERVERS["payments"]
-            and "key" in settings.LASKE_SERVERS["payments"]
-        ):
+        key_type = settings.LASKE_SERVERS["payments"].get("key_type")
+        key = settings.LASKE_SERVERS["payments"].get("key")
+
+        if key_type and key:
             logger.info("Key found, using SFTP")
             self.download_payments_sftp()
         else:


### PR DESCRIPTION
No point in trying with SFTP if key and key_type keys are present in the settings, but have empty value.