### PR TITLE
Revoke all privileges before dropping the role

### DIFF
--- a/leasing/migrations/0113_remove_vipunen_view.sql
+++ b/leasing/migrations/0113_remove_vipunen_view.sql
@@ -1,8 +1,15 @@
--- Remove role `kami`'s permissions
-REVOKE ALL PRIVILEGES ON SCHEMA public FROM kami;
-REVOKE ALL PRIVILEGES ON public.paikkatietovipunen_vuokraalueet FROM kami;
--- Remove `kami` role
--- Potentially there could be a problem if the role has an active connection
-DROP ROLE IF EXISTS kami;
+DO
+$$BEGIN
+    IF EXISTS (
+        SELECT FROM pg_roles
+        WHERE rolname = 'kami'
+    ) THEN
+        -- Revoke all privileges granted to the role
+        DROP OWNED BY kami;
+        -- Remove role
+        DROP ROLE kami;
+    END IF;
+END$$;
+
 -- Drop Vipunen database view
 DROP VIEW IF EXISTS public.paikkatietovipunen_vuokraalueet;


### PR DESCRIPTION
Some privileges might have been manually added to the afterwards. DROP OWNED BY will revoke them all without needing to list them.