### PR TITLE
Give Valmistelija edit access to plots and plan units

### DIFF
--- a/leasing/management/commands/set_group_field_permissions.py
+++ b/leasing/management/commands/set_group_field_permissions.py
@@ -401,7 +401,7 @@ DEFAULT_FIELD_PERMS = {
     },
     "plot": {
         UG.SELAILIJA: "view",
-        UG.VALMISTELIJA: "view",
+        UG.VALMISTELIJA: "change",
         UG.SOPIMUSVALMISTELIJA: "view",
         UG.SYOTTAJA: "change",
         UG.PERINTALAKIMIES: "view",
@@ -428,7 +428,7 @@ DEFAULT_FIELD_PERMS = {
     },
     "planunit": {
         UG.SELAILIJA: "view",
-        UG.VALMISTELIJA: "view",
+        UG.VALMISTELIJA: "change",
         UG.SOPIMUSVALMISTELIJA: "view",
         UG.SYOTTAJA: "change",
         UG.PERINTALAKIMIES: "view",
@@ -615,8 +615,8 @@ CUSTOM_FIELD_PERMS = {
         "tenantcontact_set": {UG.LASKUTTAJA: "change"},
     },
     "leasearea": {
-        "plots": {UG.VALMISTELIJA: "view", UG.PERINTALAKIMIES: "view"},
-        "plan_units": {UG.VALMISTELIJA: "view", UG.PERINTALAKIMIES: "view"},
+        "plots": {UG.PERINTALAKIMIES: "view"},
+        "plan_units": {UG.PERINTALAKIMIES: "view"},
         "archived_at": {UG.VALMISTELIJA: "view", UG.PERINTALAKIMIES: "view"},
         "archived_note": {UG.VALMISTELIJA: "view", UG.PERINTALAKIMIES: "view"},
         "archived_decision": {UG.VALMISTELIJA: "view", UG.PERINTALAKIMIES: "view"},

--- a/leasing/management/commands/set_group_model_permissions.py
+++ b/leasing/management/commands/set_group_model_permissions.py
@@ -808,7 +808,7 @@ DEFAULT_MODEL_PERMS = {
     },
     "plot": {
         UG.SELAILIJA: ("view",),
-        UG.VALMISTELIJA: ("view",),
+        UG.VALMISTELIJA: ("view", "add", "change", "delete"),
         UG.SOPIMUSVALMISTELIJA: ("view",),
         UG.SYOTTAJA: ("view", "add", "change", "delete"),
         UG.PERINTALAKIMIES: ("view",),
@@ -935,7 +935,7 @@ DEFAULT_MODEL_PERMS = {
     },
     "planunit": {
         UG.SELAILIJA: ("view",),
-        UG.VALMISTELIJA: ("view",),
+        UG.VALMISTELIJA: ("view", "add", "change", "delete"),
         UG.SOPIMUSVALMISTELIJA: ("view",),
         UG.SYOTTAJA: ("view", "add", "change", "delete"),
         UG.PERINTALAKIMIES: ("view",),


### PR DESCRIPTION
These details are part of the contracts, which means valmistelija should be able to add/change/delete them in the Vuokra-alue tab.