### PR TITLE
Promote faker to a main dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,8 +70,10 @@ factory-boy==3.3.3
     # via
     #   -r requirements-dev.in
     #   pytest-factoryboy
-faker==25.2.0
-    # via factory-boy
+faker==40.13.0
+    # via
+    #   -c requirements.txt
+    #   factory-boy
 flake8==7.3.0
     # via
     #   -r requirements-dev.in
@@ -164,18 +166,10 @@ pytest-django==4.11.1
     # via -r requirements-dev.in
 pytest-factoryboy==2.8.1
     # via -r requirements-dev.in
-python-dateutil==2.9.0.post0
-    # via
-    #   -c requirements.txt
-    #   faker
 requests==2.32.5
     # via
     #   -c requirements.txt
     #   djangorestframework-stubs
-six==1.16.0
-    # via
-    #   -c requirements.txt
-    #   python-dateutil
 sqlparse==0.5.0
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -27,6 +27,7 @@ djangorestframework==3.16.1
 djangorestframework-gis==1.2.0
 drf-yasg[validation]==1.21.11
 docxtpl==0.20.2
+faker==40.13.0
 helsinki-profile-gdpr-api~=0.2.0
 lxml==6.0.2
 oracledb==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,6 +155,8 @@ elastic-transport==8.17.1
     # via elasticsearch8
 elasticsearch8==8.19.3
     # via django-resilient-logger
+faker==40.13.0
+    # via -r requirements.in
 helsinki-profile-gdpr-api==0.2.0
     # via -r requirements.in
 html5lib==1.1
@@ -242,6 +244,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements.in
     #   django-auditlog
     #   elasticsearch8
+    #   faker
 python-docx==1.1.2
     # via docxtpl
 python-jose==3.5.0


### PR DESCRIPTION
This is necessary in order to run `create_sanitized_dump` management command in production, which does not have dev requirements installed.

Also, adds a constraint to `requirements-dev.in` that all the installed versions must align with the main `requirements.in` file.