### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,7 @@
 
 # Local settings and secrets
 local_settings.py
-.env
+.env*
 *.env.yaml
 
 # Python build artifacts

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Version control
+.git/
+.github/
+
+# Local development / IDE
+.devcontainer/
+.vscode/
+.idea/
+.DS_Store
+
+# Local settings and secrets
+local_settings.py
+.env
+*.env.yaml
+
+# Python build artifacts
+*.py[cod]
+*.mo
+.mypy_cache/
+.cache/
+.pytest_cache/
+.tox/
+.coverage*
+coverage.xml
+
+# Runtime / generated directories
+/media/
+/private_files/
+/static/
+/venv/
+/.venv/
+
+# Data files that should not be in the image
+*.sql
+*.dump
+*.csv
+*.xlsx
+*.log
+/laske_export_files/
+/nls_leasehold_transfers/
+/tmp_backups_for_db_restore/
+
+# Pipelines (not needed at runtime)
+pipelines/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 .vscode
 /local_settings.py
 .devcontainer/docker-compose.env
-/.env
+/.env*
 /*.env.yaml
 /.venv
 /.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@
 /nls_leasehold_transfers/
 /tmp_backups_for_db_restore/
 .mypy_cache
-PCF_20181128.dat
 coverage.xml


### PR DESCRIPTION
This helps avoid unexpectedly copying sensitive or unnecessary files or data to deployed containers.