### PR TITLE
Update sanitizer configuration

### DIFF
--- a/.sanitizerconfig
+++ b/.sanitizerconfig
@@ -413,7 +413,7 @@ strategy:
   leasing_contact:
     address: mvj.street_address_if_exist
     address_protection: null
-    business_id: mvj.business_id_if_exist
+    business_id: null
     care_of: mvj.company_if_exist
     city: mvj.city_if_exist
     country: null

--- a/README.md
+++ b/README.md
@@ -496,13 +496,13 @@ another management command. Read the command's input parameters for more things 
 back up, if you see necessary:
 
 ```bash
-python manage.py database_backup_before_load DB_NAME DB_HOST DB_PORT DB_USER BACKUP_DIR
+python manage.py database_backup_before_load DB_NAME DB_HOST DB_PORT DB_USER BACKUP_DIR --binary-dump
 ```
 
 ### 5. Load the sanitized dump
 
 ```bash
-psql --dbname DB_NAME --host DB_HOST -port DB_PORT ---username DB_USER --file /path/to/sanitized_DATETIME.sql > dump_loading.log
+psql --dbname DB_NAME --host DB_HOST --port DB_PORT ---username DB_USER --file /path/to/sanitized_DATETIME.sql > dump_loading.log
 ```
 
 ### 6. Restore environment-specific data


### PR DESCRIPTION
Don't sanitize business ID for contacts. It is needed for upcoming
development task. Business IDs are public information, and doesn't
produce anything more in addition to the company name available in
contacts already.