### PR TITLE
Add missing archived_at to lease area geometry

### DIFF
--- a/leasing/serializers/land_area.py
+++ b/leasing/serializers/land_area.py
@@ -549,6 +549,7 @@ class LeaseAreaSuccinctWithGeometryListSerializer(LeaseAreaListSerializer):
             "id",
             "identifier",
             "geometry",
+            "archived_at",
         )
 
 


### PR DESCRIPTION
The archived_at was omitted from the recently added succinct lease area with geometry serializer, but it is used in UI for filtering.