### PR TITLE
MVJ-1219 Improve invoice recipient logic

### DIFF
--- a/.sanitizerconfig
+++ b/.sanitizerconfig
@@ -1170,7 +1170,7 @@ strategy:
     id: null
     lease_id: null
     modified_at: null
-    reference: null
+    reference: mvj.generate_random_numbers_if_exist
     share_denominator: null
     share_numerator: null
   leasing_tenantcontact:

--- a/file_operations/viewsets/mixins.py
+++ b/file_operations/viewsets/mixins.py
@@ -216,7 +216,7 @@ class FileExtensionFileMixin:
     def _validate_file_extensions(self, files: MultiValueDict) -> NoReturn:
         """
         Validate file extensions of uploaded files from the file extension.
-        Does not validate the the file type from the first bytes of the tile,
+        Does not validate the file type from the first bytes of the tile,
         nor does it validate the content type / mimetype of the file.
 
         Raises:

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -156,7 +156,7 @@ class InvoiceSalesOrderAdapter:
 
         return "\n".join(bill_texts)
 
-    def get_first_tenant(self) -> Tenant | None:
+    def get_first_tenant_from_invoicerows(self) -> Tenant | None:
         for invoice_row in self.invoice.rows.all():
             if not invoice_row.tenant:
                 continue
@@ -166,7 +166,7 @@ class InvoiceSalesOrderAdapter:
         return None
 
     def get_contact_to_bill(self) -> Contact:
-        tenant = self.get_first_tenant()
+        tenant = self.get_first_tenant_from_invoicerows()
         # We need a tenant and time period to find the BILLING contact
         if not tenant or not self.invoice.billing_period_start_date:
             return self.invoice.recipient
@@ -445,7 +445,12 @@ class InvoiceSalesOrderAdapter:
         #       Make, or something else? Maybe return empty string instead?
         return SapSalesOfficeNumber.MAKE.value  # type: ignore[no-any-return]
 
-    def set_values(self) -> None:
+    def set_values(self) -> Contact:
+        """
+        Sets the values of the sales order based on the invoice and service unit.
+
+        Returns: The contact to be billed for the invoice.
+        """
         self.sales_order.set_bill_texts_from_string(self.get_bill_text())
 
         contact_to_be_billed = self.get_contact_to_bill()
@@ -471,6 +476,8 @@ class InvoiceSalesOrderAdapter:
         self.set_payment_reference()
 
         self.sales_order.line_items = self.get_line_items()
+
+        return contact_to_be_billed
 
 
 class KamaInvoiceSalesOrderAdapter(InvoiceSalesOrderAdapter):

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -660,9 +660,9 @@ def _sort_invoice_rows_for_lineitems(
     Credit note rows (negative amounts) should be second.
     Rounding rows (very small amounts, positive or negative) should be last.
     """
-    charges = []
-    credits = []
-    roundings = []
+    charges: list[InvoiceRow] = []
+    credits: list[InvoiceRow] = []
+    roundings: list[InvoiceRow] = []
     # The rounding threshold is a guesstimate by the developer.
     # It should be small enough to not include "real" invoice rows,
     # but large enough to include all rounding rows.
@@ -681,6 +681,6 @@ def _sort_invoice_rows_for_lineitems(
     sorted_charges = sorted(charges, key=lambda r: r.amount, reverse=True)
     # Example: -50, -25, -10
     sorted_credits = sorted(credits, key=lambda r: abs(r.amount), reverse=True)
-    # Example: 0.05, -0.01
+    # Example: 0.01, -0.05
     sorted_roundings = sorted(roundings, key=lambda r: r.amount, reverse=True)
     return sorted_charges + sorted_credits + sorted_roundings

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 
 from laske_export.document.custom_validators import calculate_checksum
 from leasing.enums import (
@@ -14,6 +14,7 @@ from leasing.enums import (
     SapSalesOfficeNumber,
     SapSalesOrgNumber,
     ServiceUnitId,
+    TenantContactType,
 )
 from leasing.models import Contact, Invoice, InvoiceRow, ServiceUnit, Tenant
 from leasing.models.lease import LeaseType
@@ -171,15 +172,51 @@ class InvoiceSalesOrderAdapter:
         if not tenant or not self.invoice.billing_period_start_date:
             return self.invoice.recipient
 
-        # This method returns the TENANT contact if there's no BILLING contact
-        tenant_billingcontact = tenant.get_billing_tenantcontacts(
-            self.invoice.billing_period_start_date, self.invoice.billing_period_end_date
+        billing_period_start = self.invoice.billing_period_start_date
+        billing_period_end = self.invoice.billing_period_end_date
+
+        billing_tenantcontacts = tenant.get_tenantcontacts_for_period(
+            TenantContactType.BILLING, billing_period_start, billing_period_end
+        )
+        newest_billing_contact = billing_tenantcontacts.first()
+
+        if newest_billing_contact:
+            # If the most recent billing contact ends during the billing period
+            # and no other billing contact covers through the end of the period,
+            # fall back to tenant contacts instead of using a partially-covering
+            # billing contact.
+            if (
+                newest_billing_contact.end_date
+                and billing_period_end
+                and newest_billing_contact.end_date < billing_period_end
+            ):
+                any_billing_contact_has_full_coverage = billing_tenantcontacts.filter(
+                    Q(end_date__isnull=True) | Q(end_date__gte=billing_period_end)
+                ).exists()
+
+                if not any_billing_contact_has_full_coverage:
+                    # ... then fall back to tenant contacts.
+                    tenant_contact = tenant.get_tenant_tenantcontacts(
+                        billing_period_start, billing_period_end
+                    ).first()
+                    if tenant_contact:
+                        return tenant_contact.contact
+
+                    # No valid tenant contacts either, so fall back to invoice recipient.
+                    return self.invoice.recipient
+
+            # Most recent billing contact has full coverage for the billing period, so use it.
+            return newest_billing_contact.contact
+
+        # No billing contacts at all for the period; try tenant contacts.
+        tenant_contact = tenant.get_tenant_tenantcontacts(
+            billing_period_start, billing_period_end
         ).first()
 
-        if not tenant_billingcontact:
-            return self.invoice.recipient
+        if tenant_contact:
+            return tenant_contact.contact
 
-        return tenant_billingcontact.contact
+        return self.invoice.recipient
 
     def get_po_number(self) -> str | None:
         # Simply return the first reference ("viite") we come across

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -495,6 +495,12 @@ class InvoiceSalesOrderAdapter:
 
         This ensures that MVJ database and SAP have the same invoice recipient.
         """
+        if contact_to_be_billed is None:
+            logger.warning(
+                "No contact to be billed found, invoice recipient will not be updated."
+            )
+            return
+
         if self.invoice.recipient != contact_to_be_billed:
             self.invoice.recipient = contact_to_be_billed
             self.invoice.save()

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -191,7 +191,11 @@ class InvoiceSalesOrderAdapter:
                 and newest_billing_contact.end_date < billing_period_end
             ):
                 any_billing_contact_has_full_coverage = billing_tenantcontacts.filter(
-                    Q(end_date__isnull=True) | Q(end_date__gte=billing_period_end)
+                    (
+                        Q(start_date__lte=billing_period_start)
+                        | Q(start_date__isnull=True)
+                    )
+                    & (Q(end_date__isnull=True) | Q(end_date__gte=billing_period_end))
                 ).exists()
 
                 if not any_billing_contact_has_full_coverage:

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -482,15 +482,37 @@ class InvoiceSalesOrderAdapter:
         #       Make, or something else? Maybe return empty string instead?
         return SapSalesOfficeNumber.MAKE.value  # type: ignore[no-any-return]
 
-    def set_values(self) -> Contact:
+    def _update_invoice_recipient_if_changed(
+        self,
+        contact_to_be_billed: Contact,
+    ) -> None:
+        """
+        Update the invoice recipient to the contact to be billed, if they are different.
+
+        This ensures that MVJ database and SAP have the same invoice recipient.
+        """
+        if self.invoice.recipient != contact_to_be_billed:
+            self.invoice.recipient = contact_to_be_billed
+            self.invoice.save()
+            logger.info(
+                f"Updated invoice recipient to contact id {contact_to_be_billed.pk}."
+            )
+
+    def set_values(self, update_invoice_recipient: bool = False) -> None:
         """
         Sets the values of the sales order based on the invoice and service unit.
 
-        Returns: The contact to be billed for the invoice.
+        Args:
+            update_invoice_recipient: Whether to update the self.invoice.recipient to the contact to be billed
+
+        Returns: None
         """
         self.sales_order.set_bill_texts_from_string(self.get_bill_text())
 
         contact_to_be_billed = self.get_contact_to_bill()
+
+        if update_invoice_recipient:
+            self._update_invoice_recipient_if_changed(contact_to_be_billed)
 
         order_party = OrderParty(fill_priority_and_info=self.fill_priority_and_info)
         order_party.from_contact(contact_to_be_billed)
@@ -513,8 +535,6 @@ class InvoiceSalesOrderAdapter:
         self.set_payment_reference()
 
         self.sales_order.line_items = self.get_line_items()
-
-        return contact_to_be_billed
 
 
 class KamaInvoiceSalesOrderAdapter(InvoiceSalesOrderAdapter):

--- a/laske_export/document/invoice_sales_order_adapter.py
+++ b/laske_export/document/invoice_sales_order_adapter.py
@@ -178,17 +178,17 @@ class InvoiceSalesOrderAdapter:
         billing_tenantcontacts = tenant.get_tenantcontacts_for_period(
             TenantContactType.BILLING, billing_period_start, billing_period_end
         )
-        newest_billing_contact = billing_tenantcontacts.first()
+        billing_contact_with_latest_start_date = billing_tenantcontacts.first()
 
-        if newest_billing_contact:
+        if billing_contact_with_latest_start_date:
             # If the most recent billing contact ends during the billing period
             # and no other billing contact covers through the end of the period,
             # fall back to tenant contacts instead of using a partially-covering
             # billing contact.
             if (
-                newest_billing_contact.end_date
+                billing_contact_with_latest_start_date.end_date
                 and billing_period_end
-                and newest_billing_contact.end_date < billing_period_end
+                and billing_contact_with_latest_start_date.end_date < billing_period_end
             ):
                 any_billing_contact_has_full_coverage = billing_tenantcontacts.filter(
                     (
@@ -210,7 +210,7 @@ class InvoiceSalesOrderAdapter:
                     return self.invoice.recipient
 
             # Most recent billing contact has full coverage for the billing period, so use it.
-            return newest_billing_contact.contact
+            return billing_contact_with_latest_start_date.contact
 
         # No billing contacts at all for the period; try tenant contacts.
         tenant_contact = tenant.get_tenant_tenantcontacts(

--- a/laske_export/exporter.py
+++ b/laske_export/exporter.py
@@ -17,6 +17,7 @@ from laske_export.enums import LaskeExportLogInvoiceStatus
 from laske_export.models import LaskeExportLog, LaskeExportLogInvoiceItem
 from leasing.enums import InvoiceType
 from leasing.models import Invoice, ServiceUnit
+from leasing.models.contact import Contact
 
 logger = logging.getLogger(__name__)
 
@@ -138,14 +139,14 @@ class LaskeExporter:
                 invoice.save()
 
             sales_order = create_sales_order_with_laske_values(invoice.service_unit)
-
             adapter = invoice_sales_order_adapter_factory(
                 invoice=invoice,
                 sales_order=sales_order,
                 service_unit=self.service_unit,
                 fill_priority_and_info=self.service_unit.laske_fill_priority_and_info,
             )
-            adapter.set_values()
+            contact_to_be_billed = adapter.set_values()
+            self._update_invoice_recipient_if_changed(invoice, contact_to_be_billed)
 
             try:
                 sales_order.validate()
@@ -214,3 +215,22 @@ class LaskeExporter:
         laske_export_log_entry.save()
 
         return laske_export_log_entry
+
+    def _update_invoice_recipient_if_changed(
+        self,
+        invoice: Invoice,
+        contact_to_be_billed: Contact,
+    ) -> None:
+        """
+        Update the invoice recipient to the contact to be billed, if they are different.
+
+        This ensures that MVJ database and SAP have the same invoice recipient.
+        """
+        if invoice.recipient != contact_to_be_billed:
+            invoice.recipient = contact_to_be_billed
+            invoice.save()
+            self.write_to_output(
+                " Updated invoice recipient to contact id {}.".format(
+                    contact_to_be_billed.pk
+                )
+            )

--- a/laske_export/exporter.py
+++ b/laske_export/exporter.py
@@ -17,7 +17,6 @@ from laske_export.enums import LaskeExportLogInvoiceStatus
 from laske_export.models import LaskeExportLog, LaskeExportLogInvoiceItem
 from leasing.enums import InvoiceType
 from leasing.models import Invoice, ServiceUnit
-from leasing.models.contact import Contact
 
 logger = logging.getLogger(__name__)
 
@@ -145,8 +144,7 @@ class LaskeExporter:
                 service_unit=self.service_unit,
                 fill_priority_and_info=self.service_unit.laske_fill_priority_and_info,
             )
-            contact_to_be_billed = adapter.set_values()
-            self._update_invoice_recipient_if_changed(invoice, contact_to_be_billed)
+            adapter.set_values(update_invoice_recipient=True)
 
             try:
                 sales_order.validate()
@@ -215,22 +213,3 @@ class LaskeExporter:
         laske_export_log_entry.save()
 
         return laske_export_log_entry
-
-    def _update_invoice_recipient_if_changed(
-        self,
-        invoice: Invoice,
-        contact_to_be_billed: Contact,
-    ) -> None:
-        """
-        Update the invoice recipient to the contact to be billed, if they are different.
-
-        This ensures that MVJ database and SAP have the same invoice recipient.
-        """
-        if invoice.recipient != contact_to_be_billed:
-            invoice.recipient = contact_to_be_billed
-            invoice.save()
-            self.write_to_output(
-                " Updated invoice recipient to contact id {}.".format(
-                    contact_to_be_billed.pk
-                )
-            )

--- a/laske_export/tests/conftest.py
+++ b/laske_export/tests/conftest.py
@@ -397,6 +397,7 @@ def exporter_lacking_test_setup(
         total_amount=Decimal("123.45"),
         billed_amount=Decimal("123.45"),
         outstanding_amount=Decimal("123.45"),
+        invoicing_date=datetime.date(year=2024, month=1, day=1),
         recipient=contact_factory(
             first_name=None,
             last_name=None,
@@ -461,3 +462,52 @@ def _setup_service_unit_for_tests(
     service_unit.default_receivable_type_collateral = default_receivable_type_collateral
     service_unit.save()
     return service_unit
+
+
+@pytest.fixture
+def invoice_sales_order_adapter_billing_contact_test_setup(
+    request: pytest.FixtureRequest,  # will be indirectly passed via pytest.mark.parametrize
+    contact_factory,
+    district_factory,
+    intended_use_factory,
+    lease_factory,
+    lease_type_factory,
+    receivable_type_factory,
+    rent_intended_use_factory,
+) -> dict[str, Any]:
+    """
+    Default test data fixture for invoice_sales_order_adapter tests relating to
+    billing contact resolution.
+    """
+    service_unit_id: ServiceUnitId = request.param
+    service_unit = _setup_service_unit_for_tests(
+        service_unit_id, receivable_type_factory
+    )
+    lease = lease_factory(
+        service_unit=service_unit,
+        lessor=contact_factory(service_unit=service_unit, sap_sales_office="1234"),
+        district=district_factory(identifier="99", name="District name"),
+        intended_use=intended_use_factory(
+            name="Lease Intended Use name", service_unit=service_unit
+        ),
+        type=lease_type_factory(
+            name="Lease Type name",
+            sap_material_code="11111111",
+            sap_project_number="1111111111",
+        ),
+    )
+    invoicerow_receivable_type = receivable_type_factory(
+        name="Invoice Row Receivable Type name",
+        service_unit=service_unit,
+        sap_material_code="11111111",
+        sap_project_number="1111111111",
+    )
+    invoicerow_intended_use = rent_intended_use_factory(
+        name="Invoice Row Intended Use name"
+    )
+    return {
+        "service_unit": service_unit,
+        "lease": lease,
+        "invoicerow_receivable_type": invoicerow_receivable_type,
+        "invoicerow_intended_use": invoicerow_intended_use,
+    }

--- a/laske_export/tests/conftest.py
+++ b/laske_export/tests/conftest.py
@@ -478,14 +478,23 @@ def invoice_sales_order_adapter_billing_contact_test_setup(
     contact_factory: Callable[..., Contact],
     district_factory: Callable[..., District],
     intended_use_factory: Callable[..., IntendedUse],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
     lease_factory: Callable[..., Lease],
     lease_type_factory: Callable[..., LeaseType],
     receivable_type_factory: Callable[..., ReceivableType],
-    rent_intended_use_factory: Callable[..., RentIntendedUse],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
 ) -> dict[str, Any]:
     """
-    Default test data fixture for invoice_sales_order_adapter tests relating to
-    billing contact resolution.
+    Default test data fixture for billing contact resolution tests.
+
+    Creates a shared setup with:
+    - service unit with required receivable types,
+    - lease with required related objects,
+    - tenant with tenant contact and billing contact, both starting Jan 1 2026,
+    - invoice for December 2026 billing period,
+    - invoice row for the tenant.
     """
     service_unit_id: ServiceUnitId = request.param
     service_unit = _setup_service_unit_for_tests(
@@ -510,12 +519,67 @@ def invoice_sales_order_adapter_billing_contact_test_setup(
         sap_material_code="11111111",
         sap_project_number="1111111111",
     )
-    invoicerow_intended_use = rent_intended_use_factory(
-        name="Invoice Row Intended Use name"
+
+    # Common tenant setup starting Jan 1 2026, with no end date
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
     )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact = tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    billing_contacts_contact = contact_factory(
+        first_name="Original",
+        last_name="Billing Contact",
+        sap_customer_number="1111111111",
+    )
+    billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=billing_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Common invoice setup for December 2026 billing period
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=billing_contacts_contact,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
     return {
         "service_unit": service_unit,
         "lease": lease,
         "invoicerow_receivable_type": invoicerow_receivable_type,
-        "invoicerow_intended_use": invoicerow_intended_use,
+        "tenant": tenant,
+        "tenant_contact": tenant_contact,
+        "tenant_contacts_contact": tenant_contacts_contact,
+        "billing_contact": billing_contact,
+        "billing_contacts_contact": billing_contacts_contact,
+        "invoice": invoice,
+        "billing_period_start_date": billing_period_start_date,
+        "billing_period_end_date": billing_period_end_date,
     }

--- a/laske_export/tests/conftest.py
+++ b/laske_export/tests/conftest.py
@@ -16,8 +16,16 @@ from laske_export.document.invoice_sales_order_adapter import (
 from laske_export.exporter import LaskeExporter, create_sales_order_with_laske_values
 from laske_export.management.commands import send_invoices_to_laske
 from leasing.enums import ContactType, ServiceUnitId, TenantContactType
+from leasing.models import District
+from leasing.models.contact import Contact
+from leasing.models.decision import Decision
+from leasing.models.invoice import Invoice, InvoiceRow
+from leasing.models.land_area import LeaseArea, LeaseAreaAddress
+from leasing.models.lease import IntendedUse, Lease, LeaseType
 from leasing.models.receivable_type import ReceivableType
+from leasing.models.rent import RentIntendedUse
 from leasing.models.service_unit import ServiceUnit
+from leasing.models.tenant import Tenant, TenantContact
 from leasing.tests.conftest import *  # noqa
 
 
@@ -120,8 +128,8 @@ def send_invoices_to_laske_command() -> BaseCommand:
 
 @pytest.fixture
 def send_invoices_to_laske_command_handle(
-    broken_invoice,
-    invoice,
+    broken_invoice,  # Fixture initialized in test file
+    invoice,  # Fixture initialized in test file
     send_invoices_to_laske_command: BaseCommand,
     monkeypatch_laske_exporter_send,
     mock_sftp,
@@ -132,8 +140,8 @@ def send_invoices_to_laske_command_handle(
 
 @pytest.fixture
 def send_invoices_to_laske_command_handle_with_unexpected_error(
-    broken_invoice,
-    invoice,
+    broken_invoice,  # Fixture initialized in test file
+    invoice,  # Fixture initialized in test file
     send_invoices_to_laske_command: BaseCommand,
     monkeypatch_laske_exporter_send_with_error,
     mock_sftp,
@@ -148,20 +156,20 @@ def exporter_full_test_setup(
     settings,
     tmp_path,  # Unique path provided by pytest: /tmp/pytest-of-vscode/pytest-<num>
     request: pytest.FixtureRequest,  # will be indirectly passed via pytest.mark.parametrize
-    contact_factory,
-    decision_factory,
-    district_factory,
-    intended_use_factory,
-    invoice_factory,
-    invoice_row_factory,
-    lease_factory,
-    lease_area_factory,
-    lease_area_address_factory,
-    lease_type_factory,
-    receivable_type_factory,
-    rent_intended_use_factory,
-    tenant_factory,
-    tenant_contact_factory,
+    contact_factory: Callable[..., Contact],
+    decision_factory: Callable[..., Decision],
+    district_factory: Callable[..., District],
+    intended_use_factory: Callable[..., IntendedUse],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+    lease_factory: Callable[..., Lease],
+    lease_area_factory: Callable[..., LeaseArea],
+    lease_area_address_factory: Callable[..., LeaseAreaAddress],
+    lease_type_factory: Callable[..., LeaseType],
+    receivable_type_factory: Callable[..., ReceivableType],
+    rent_intended_use_factory: Callable[..., RentIntendedUse],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
 ) -> dict[str, Any]:
     """Default test data fixture for exporter tests."""
     # Ensure a unique directory for each test, so that the export XML can be
@@ -327,15 +335,15 @@ def exporter_lacking_test_setup(
     settings,
     tmp_path,  # Unique path provided by pytest: /tmp/pytest-of-vscode/pytest-<num>
     request: pytest.FixtureRequest,  # will be indirectly passed via pytest.mark.parametrize
-    contact_factory,
-    district_factory,
-    invoice_factory,
-    invoice_row_factory,
-    lease_factory,
-    lease_type_factory,
-    receivable_type_factory,
-    tenant_factory,
-    tenant_contact_factory,
+    contact_factory: Callable[..., Contact],
+    district_factory: Callable[..., District],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+    lease_factory: Callable[..., Lease],
+    lease_type_factory: Callable[..., LeaseType],
+    receivable_type_factory: Callable[..., ReceivableType],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
 ) -> dict[str, Any]:
     """
     Testing data fixture for KAMA-related exporter tests.
@@ -467,13 +475,13 @@ def _setup_service_unit_for_tests(
 @pytest.fixture
 def invoice_sales_order_adapter_billing_contact_test_setup(
     request: pytest.FixtureRequest,  # will be indirectly passed via pytest.mark.parametrize
-    contact_factory,
-    district_factory,
-    intended_use_factory,
-    lease_factory,
-    lease_type_factory,
-    receivable_type_factory,
-    rent_intended_use_factory,
+    contact_factory: Callable[..., Contact],
+    district_factory: Callable[..., District],
+    intended_use_factory: Callable[..., IntendedUse],
+    lease_factory: Callable[..., Lease],
+    lease_type_factory: Callable[..., LeaseType],
+    receivable_type_factory: Callable[..., ReceivableType],
+    rent_intended_use_factory: Callable[..., RentIntendedUse],
 ) -> dict[str, Any]:
     """
     Default test data fixture for invoice_sales_order_adapter tests relating to

--- a/laske_export/tests/test_exporter.py
+++ b/laske_export/tests/test_exporter.py
@@ -6,6 +6,7 @@ import tempfile
 import xml.etree.ElementTree as et  # noqa
 from decimal import Decimal
 from glob import glob
+from typing import Callable
 
 import pytest
 from django.conf import settings
@@ -15,9 +16,13 @@ from django.test import override_settings
 from laske_export.enums import LaskeExportLogInvoiceStatus
 from laske_export.exporter import LaskeExporter
 from laske_export.models import LaskeExportLog
-from leasing.enums import ServiceUnitId
-from leasing.models.contact import ContactType
-from leasing.models.invoice import Invoice
+from leasing.enums import ServiceUnitId, TenantContactType
+from leasing.models.contact import Contact, ContactType
+from leasing.models.invoice import Invoice, InvoiceRow
+from leasing.models.lease import Lease
+from leasing.models.receivable_type import ReceivableType
+from leasing.models.service_unit import ServiceUnit
+from leasing.models.tenant import Tenant, TenantContact
 
 from .conftest import (
     get_exported_file_as_tree,
@@ -26,14 +31,14 @@ from .conftest import (
 
 
 @pytest.fixture
-def billing_period():
+def billing_period() -> tuple[datetime.date, datetime.date]:
     billing_period_start_date = datetime.date(year=2017, month=7, day=1)
     billing_period_end_date = datetime.date(year=2017, month=12, day=31)
     return billing_period_start_date, billing_period_end_date
 
 
 @pytest.fixture
-def lease(lease_factory):
+def lease(lease_factory: Callable[..., Lease]) -> Lease:
     lease = lease_factory(
         type_id=1, municipality_id=1, district_id=5, notice_period_id=1
     )
@@ -41,7 +46,12 @@ def lease(lease_factory):
 
 
 @pytest.fixture
-def invoice(contact_factory, invoice_factory, lease, billing_period):
+def invoice(
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    lease,
+    billing_period,
+):
     billing_period_start_date, billing_period_end_date = billing_period
 
     contact = contact_factory(
@@ -64,7 +74,12 @@ def invoice(contact_factory, invoice_factory, lease, billing_period):
 
 
 @pytest.fixture
-def broken_invoice(contact_factory, invoice_factory, lease, billing_period):
+def broken_invoice(
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    lease,
+    billing_period,
+):
     billing_period_start_date, billing_period_end_date = billing_period
 
     broken_contact = contact_factory(
@@ -88,7 +103,10 @@ def broken_invoice(contact_factory, invoice_factory, lease, billing_period):
 
 @pytest.mark.django_db
 def test_invalid_export_invoice(
-    broken_invoice, invoice, monkeypatch_laske_exporter_send, mock_sftp
+    broken_invoice,
+    invoice,
+    monkeypatch_laske_exporter_send,
+    mock_sftp,
 ):
     exporter = LaskeExporter(service_unit=invoice.service_unit)
     exporter.export_invoices([broken_invoice, invoice])
@@ -115,10 +133,10 @@ def test_invalid_export_invoice(
 
 @pytest.mark.django_db
 def test_export_invalid_invoice_not_marked_sent(
-    service_unit_factory,
-    contact_factory,
-    invoice_factory,
-    lease_factory,
+    service_unit_factory: Callable[..., ServiceUnit],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    lease_factory: Callable[..., Lease],
     monkeypatch_laske_exporter_send,
     caplog: pytest.LogCaptureFixture,
     mock_sftp,
@@ -186,14 +204,14 @@ def test_send_invoices_to_laske_command_handle_with_unexpected_error(
 def test_send_invoices_service_unit(
     settings,
     tmp_path,
-    service_unit_factory,
-    receivable_type_factory,
-    lease_factory,
-    contact_factory,
-    invoice_factory,
+    service_unit_factory: Callable[..., ServiceUnit],
+    receivable_type_factory: Callable[..., ReceivableType],
+    lease_factory: Callable[..., Lease],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
     send_invoices_to_laske_command,
     monkeypatch_laske_exporter_send,
-    service_unit_to_use,
+    service_unit_to_use: int,
     mock_sftp,
 ):
     settings.LASKE_EXPORT_ROOT = str(tmp_path)
@@ -298,13 +316,12 @@ def test_send_invoices_service_unit(
 def _order_number_test_setup(
     settings,
     tmp_path,
-    service_unit_factory,
-    receivable_type_factory,
-    lease_factory,
-    contact_factory,
-    invoice_factory,
-    invoice_row_factory,
-    send_invoices_to_laske_command,
+    service_unit_factory: Callable[..., ServiceUnit],
+    receivable_type_factory: Callable[..., ReceivableType],
+    lease_factory: Callable[..., Lease],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
     monkeypatch_laske_exporter_send,
 ):
     settings.LASKE_EXPORT_ROOT = str(tmp_path)

--- a/laske_export/tests/test_exporter.py
+++ b/laske_export/tests/test_exporter.py
@@ -494,3 +494,137 @@ def test_export_sftp(monkeypatch, mock_sftp):
         )
         laske_exporter = LaskeExporter(service_unit=ServiceUnitId.MAKE)
         laske_exporter.send(file_path)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_export_updates_invoice_recipient_when_billing_contact_changed(
+    settings,
+    tmp_path,
+    invoice_sales_order_adapter_billing_contact_test_setup,
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    monkeypatch_laske_exporter_send,
+    mock_sftp,
+):
+    """
+    When a BILLING TenantContact differs from invoice.recipient,
+    export_invoices() must update invoice.recipient in the database to the
+    current billing contact before sending to SAP.
+
+    This helps to keep MVJ and SAP in sync with the same billing information.
+    """
+    # Set up a temporary directory for the export files, so we can check the exported XML.
+    settings.LASKE_EXPORT_ROOT = str(tmp_path)
+
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+    tenant_contact_person = contact_factory(
+        first_name="Tenant", last_name="Contact Person", type=ContactType.PERSON
+    )
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contact_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_billing_person = contact_factory(
+        first_name="Original",
+        last_name="Billing Person",
+        sap_customer_number="1111111111",
+        type=ContactType.PERSON,
+    )
+    original_billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=original_billing_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_billing_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Original billing contact is ended before the billing period.
+    original_billing_contact.end_date = datetime.date(2026, 11, 30)
+    original_billing_contact.save()
+
+    new_billing_person = contact_factory(
+        first_name="New",
+        last_name="Billing Person",
+        sap_customer_number="2222222222",
+        type=ContactType.PERSON,
+    )
+    tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=new_billing_person,
+        start_date=billing_period_start_date,
+    )
+
+    exporter = LaskeExporter(service_unit=service_unit)
+    exporter.export_invoices([invoice])
+
+    # Then...
+    # The invoice recipient in database should be updated to the new billing contact.
+    invoice_from_db = Invoice.objects.get(id=invoice.pk)
+    assert invoice_from_db.recipient == new_billing_person
+    assert new_billing_person != original_billing_person
+
+    # Invoice export should have the same recipient as the updated invoice recipient.
+    files = glob(settings.LASKE_EXPORT_ROOT + "/MTIL_IN_*.xml")
+    assert len(files) == 1
+    exported_file = files[0]
+    xml_tree = et.parse(exported_file)
+    assert len(xml_tree.findall("./SBO_SalesOrder/BillingParty1")) == 1
+
+    assert (
+        xml_tree.find("./SBO_SalesOrder/BillingParty1/SAPCustomerID").text
+        == new_billing_person.sap_customer_number
+    )
+    assert (
+        new_billing_person.sap_customer_number
+        != original_billing_person.sap_customer_number
+    )

--- a/laske_export/tests/test_invoice_sales_order_adapter.py
+++ b/laske_export/tests/test_invoice_sales_order_adapter.py
@@ -1,18 +1,23 @@
+import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
 from laske_export.document.invoice_sales_order_adapter import (
     InvoiceSalesOrderAdapter,
     _sort_invoice_rows_for_lineitems,
+    invoice_sales_order_adapter_factory,
 )
 from laske_export.document.sales_order import LineItem
-from leasing.enums import ServiceUnitId
+from laske_export.exporter import create_sales_order_with_laske_values
+from leasing.enums import ServiceUnitId, TenantContactType
+from leasing.models.contact import Contact
 from leasing.models.invoice import Invoice, InvoiceRow
 from leasing.models.lease import Lease, LeaseType
 from leasing.models.receivable_type import ReceivableType
 from leasing.models.service_unit import ServiceUnit
+from leasing.models.tenant import Tenant, TenantContact
 
 
 @pytest.mark.parametrize(
@@ -174,32 +179,32 @@ def test_get_sorted_invoice_rows(exporter_full_test_setup: dict[str, Any]):
 
     receivable_type = exporter_full_test_setup["invoicerow1_receivable_type"]
 
-    row1 = InvoiceRow.objects.create(
+    charge_smaller = InvoiceRow.objects.create(
         invoice=invoice,
         amount=Decimal("100.00"),
         receivable_type=receivable_type,
     )
-    row2 = InvoiceRow.objects.create(
+    rounding_negative = InvoiceRow.objects.create(
         invoice=invoice,
-        amount=Decimal("-0.01"),
+        amount=Decimal("-0.05"),
         receivable_type=receivable_type,
     )
-    row3 = InvoiceRow.objects.create(
+    credit_smaller = InvoiceRow.objects.create(
         invoice=invoice,
         amount=Decimal("-25.00"),
         receivable_type=receivable_type,
     )
-    row4 = InvoiceRow.objects.create(
+    rounding_positive = InvoiceRow.objects.create(
         invoice=invoice,
-        amount=Decimal("0.05"),
+        amount=Decimal("0.01"),
         receivable_type=receivable_type,
     )
-    row5 = InvoiceRow.objects.create(
+    charge_larger = InvoiceRow.objects.create(
         invoice=invoice,
         amount=Decimal("200.00"),
         receivable_type=receivable_type,
     )
-    row6 = InvoiceRow.objects.create(
+    credit_larger = InvoiceRow.objects.create(
         invoice=invoice,
         amount=Decimal("-50.00"),
         receivable_type=receivable_type,
@@ -211,15 +216,1081 @@ def test_get_sorted_invoice_rows(exporter_full_test_setup: dict[str, Any]):
     # Expected order:
     # 1. Charges (positive amounts) in descending order: 200, 100
     # 2. Credits (negative amounts) in descending absolute order: -50, -25
-    # 3. Roundings (small amounts) in descending order: 0.05, -0.01
+    # 3. Roundings (small amounts) in descending order: 0.01, -0.05
     expected_order = [
-        row5,
-        row1,
-        row6,
-        row3,
-        row4,
-        row2,
+        charge_larger,
+        charge_smaller,
+        credit_larger,
+        credit_smaller,
+        rounding_positive,
+        rounding_negative,
     ]
 
     assert len(sorted_rows) == 6
     assert sorted_rows == expected_order
+
+
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+@pytest.mark.django_db
+def test_get_contact_to_bill_returns_billing_contacts_new_contact(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact's contact (laskunsaajan asiakas) is changed to another
+          contact in the UI.
+
+    Note: This is not the preferred procedure for changing the billing contact,
+    because there is no trace of dates for the change, but it is technically
+    possible.
+    The preferred way is to end the existing billing contact and create a new
+    one, which is tested in another test case.
+
+    Given:
+    - billing contact (type=billing),
+    - invoice for this billing contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - the billing contact's contact is changed to a new contact,
+
+    Then:
+    - get_contact_to_bill() should return the billing contact's new contact,
+        because they are the designated billing contact for the lease during the
+        invoice's billing period.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    # Tenantcontacts that are active for whole year of 2026.
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_contact = contact_factory(
+        first_name="Billing", last_name="Contact Original"
+    )
+
+    billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=original_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_contact,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    new_contact = contact_factory(
+        first_name="Billing",
+        last_name="Contact New",
+    )
+    billing_contact.contact = new_contact
+    billing_contact.save()
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    assert adapter.get_contact_to_bill() == new_contact
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_billing_contact_covers_billing_period_but_ends_afterwards(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact covers the invoice's billing period, but it ends afterwards.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this billing contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact ends after the billing period,
+
+    Then:
+    - get_contact_to_bill() should return the billing contact's contact, because
+        they are still responsible for the invoice's billing period.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    billing_contact_person = contact_factory(first_name="Billing", last_name="Contact")
+    billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=billing_contact_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=billing_contact_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    billing_contact.end_date = datetime.date(2027, 1, 31)
+    billing_contact.save()
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    assert adapter.get_contact_to_bill() == billing_contact_person
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_no_active_tenants(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Invoice was created for a tenant, but afterwards that tenant was ended.
+          A new tenant was added, who covers the invoice's period.
+
+    The system should send the invoice to original receiver, who will probably
+    raise the issue with Helsinki if there is a problem that is not handled by
+    Helsinki invoicers beforehand.
+
+    Such cases always require human review and intervention. The new tenant's
+    conditions are likely different from the previous tenant's conditions, which
+    means the existing invoice's contents might not be valid anymore.
+
+    Given:
+    - tenant,
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this billing contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - the tenant ends (== tenantcontact of type=tenant ends),
+    - billing contact ends,
+    - new tenant is added, that covers the billing period,
+
+    Then:
+    - get_contact_to_bill() should return the invoice's original recipient,
+      because any changes cannot be automatically handled at this point.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    original_tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    # Tenantcontacts that are active for whole year of 2026.
+    tenant_contacts_contact = contact_factory(
+        first_name="Original Tenant", last_name="Contact"
+    )
+    original_tenant_contact = tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=original_tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_contact = contact_factory(
+        first_name="Original Billing", last_name="Contact"
+    )
+    original_billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=original_tenant,
+        contact=original_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_contact,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=original_tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Old tenant is ended before invoice's billing period
+    original_tenant_contact.end_date = datetime.date(2026, 11, 30)
+    original_tenant_contact.save()
+    original_billing_contact.end_date = datetime.date(2026, 11, 30)
+    original_billing_contact.save()
+
+    # New tenant starts during invoice's billing period.
+    new_tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+    new_tenant_contacts_contact = contact_factory(
+        first_name="New Tenant", last_name="Contact"
+    )
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=new_tenant,
+        contact=new_tenant_contacts_contact,
+        start_date=datetime.date(2026, 12, 1),
+    )
+    new_billing_contacts_contact = contact_factory(
+        first_name="New Billing",
+        last_name="Contact",
+    )
+    tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=new_tenant,
+        contact=new_billing_contacts_contact,
+        start_date=datetime.date(2026, 12, 1),
+    )
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    assert adapter.get_contact_to_bill() == invoice.recipient
+    assert invoice.recipient == original_contact
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_billing_contact_ends_but_another_billing_contact_covers_billing_period(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact is ended before the invoice's billing period.
+          There is another billing contact.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this billing contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact ends before the invoice's billing period,
+    - another billing contact covers the billing period,
+
+    Then:
+    - get_contact_to_bill() should return the active billing contact's contact,
+      because they are the designated billing contact for the lease during the
+      invoice's billing period.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_billing_person = contact_factory(
+        first_name="Billing Original", last_name="Contact"
+    )
+    original_billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=original_billing_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_billing_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Original billing contact is ended before the billing period.
+    original_billing_contact.end_date = datetime.date(2026, 11, 30)
+    original_billing_contact.save()
+
+    # A new billing contact is added that covers the billing period.
+    new_billing_person = contact_factory(first_name="Billing New", last_name="Contact")
+    tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=new_billing_person,
+        start_date=datetime.date(2026, 12, 1),
+    )
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    assert adapter.get_contact_to_bill() == new_billing_person
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_billing_contact_ends_but_tenant_contact_covers_billing_period(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact is ended before the invoice's billing period.
+          No other billing contacts remain. Only the tenant contact remains.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this billing contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact ends before the invoice's billing period,
+    - no active billing contacts remain,
+    - active tenant contact remains,
+
+    Then:
+    - get_contact_to_bill() should return the tenant contact's contact,
+      because they are the main responsible party for the lease during the
+      invoice's billing period when no billing contacts are active.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    # Tenant contact: active throughout 2026 and beyond.
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_billing_person = contact_factory(first_name="Billing", last_name="Contact")
+    billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=original_billing_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_billing_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Billing contact is ended before the billing period; no new billing contact is added.
+    billing_contact.end_date = datetime.date(2026, 11, 30)
+    billing_contact.save()
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    # get_billing_tenantcontacts finds no billing contacts for Dec → falls back to tenant contacts.
+    assert adapter.get_contact_to_bill() == tenant_contacts_contact
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_billing_contact_ends_and_no_other_contacts_exist(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact is ended before the invoice's billing period.
+          No other billing contacts, or tenant contacts remain.
+
+    Note: This should not happen intentionally, because there should always be at
+    least one active tenant contact for the lease, but it is technically
+    possible.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this billing contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact ends before the invoice's billing period,
+    - no active billing contacts remain,
+    - no active tenant contacts remain,
+
+    Then:
+    - get_contact_to_bill() should return the invoice's original recipient,
+        because there are no other contacts to send the invoice to.
+
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact = tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_billing_person = contact_factory(first_name="Billing", last_name="Contact")
+    billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=original_billing_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_billing_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Both billing and tenant contacts are ended before the billing period.
+    billing_contact.end_date = datetime.date(2026, 11, 30)
+    billing_contact.save()
+    tenant_contact.end_date = datetime.date(2026, 11, 30)
+    tenant_contact.save()
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    # get_billing_tenantcontacts finds no billing contacts → falls back to tenant contacts → also none.
+    # Falls through to invoice.recipient.
+    assert adapter.get_contact_to_bill() == invoice.recipient
+    assert invoice.recipient == original_billing_person
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_newer_billing_contact_covers_billing_period_and_another_begins_midway(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact covers the entire billing period, but another billing
+    contact begins midway through the invoice's billing period.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact covers the billing period,
+    - another billing contact begins midway through the invoice's billing period,
+
+    Then:
+    - get_contact_to_bill() should return the newer billing contact's contact,
+      because it is responsible for part of the invoice's billing period, and
+      newer contacts are preferred over older contacts.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    older_billing_person = contact_factory(
+        first_name="Billing Older", last_name="Contact"
+    )
+    # Billing contact at invoice creation time: active from Jan 1, no end date.
+    tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=older_billing_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=older_billing_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # A newer billing contact is added that starts midway through the billing period.
+    newer_billing_person = contact_factory(
+        first_name="Billing Newer", last_name="Contact"
+    )
+    tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=newer_billing_person,
+        start_date=datetime.date(2026, 12, 15),
+    )
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    # get_billing_tenantcontacts returns both, ordered by -start_date → newer (Dec 15) is first.
+    assert adapter.get_contact_to_bill() == newer_billing_person
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and_another_begins(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact ends during the invoice's billing period, but another billing contact begins.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact ends during the invoice's billing period,
+    - another billing contact begins,
+
+    Then:
+    - get_contact_to_bill() should return the newer billing contact's contact,
+      because it is responsible for part of the invoice's billing period, and
+      newer contacts are preferred over older contacts.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    original_billing_person = contact_factory(
+        first_name="Billing Original", last_name="Contact"
+    )
+    # Billing contact at invoice creation time: active from Jan 1, no end date.
+    original_billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=original_billing_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=original_billing_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Original billing contact ends mid-period; a newer billing contact picks up immediately.
+    original_billing_contact.end_date = datetime.date(2026, 12, 15)
+    original_billing_contact.save()
+
+    newer_billing_person = contact_factory(
+        first_name="Billing Newer", last_name="Contact"
+    )
+    tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=newer_billing_person,
+        start_date=datetime.date(2026, 12, 16),
+    )
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    # Both billing contacts overlap the Dec period; ordered by -start_date → newer (Dec 16) is first.
+    assert adapter.get_contact_to_bill() == newer_billing_person
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # Pass the ID to the test setup fixture
+    "invoice_sales_order_adapter_billing_contact_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and_only_tenant_contact_remains(
+    invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
+    tenant_factory: Callable[..., Tenant],
+    tenant_contact_factory: Callable[..., TenantContact],
+    contact_factory: Callable[..., Contact],
+    invoice_factory: Callable[..., Invoice],
+    invoice_row_factory: Callable[..., InvoiceRow],
+):
+    """
+    Case: Billing contact ends during the invoice's billing period.
+          No other billing contacts remain. Only the tenant contact remains.
+
+    Given:
+    - tenant contact (type=tenant),
+    - billing contact (type=billing),
+    - invoice for this contact,
+    - invoice rows for this tenant,
+    - billing period when the contacts are active,
+
+    When:
+    - billing contact ends during the invoice's billing period,
+    - no other billing contacts remain,
+    - active tenant contact remains,
+
+    Then:
+    - get_contact_to_bill() should return the tenant contact's contact,
+      because the expired billing contact might not want to receive the invoices
+      from period when they are only partially responsible.
+      The tenant contact is the main responsible party for the lease during the
+      invoice's billing period.
+    """
+    # Given...
+    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
+    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
+        "service_unit"
+    ]
+
+    tenant = tenant_factory(
+        lease=lease,
+        share_numerator=1,
+        share_denominator=1,
+        reference=None,
+    )
+
+    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
+    # Tenant contact: active throughout the billing period.
+    tenant_contact_factory(
+        type=TenantContactType.TENANT,
+        tenant=tenant,
+        contact=tenant_contacts_contact,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    billing_contact_person = contact_factory(first_name="Billing", last_name="Contact")
+    # Billing contact at invoice creation time: active from Jan 1, no end date.
+    billing_contact = tenant_contact_factory(
+        type=TenantContactType.BILLING,
+        tenant=tenant,
+        contact=billing_contact_person,
+        start_date=datetime.date(2026, 1, 1),
+    )
+
+    # Invoice for December 2026, originally issued to the active billing contact.
+    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
+    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
+
+    invoice = invoice_factory(
+        lease=lease,
+        total_amount=Decimal("111.11"),
+        billed_amount=Decimal("111.11"),
+        outstanding_amount=Decimal("111.11"),
+        recipient=billing_contact_person,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+    )
+    invoicerow_receivable_type: ReceivableType = (
+        invoice_sales_order_adapter_billing_contact_test_setup[
+            "invoicerow_receivable_type"
+        ]
+    )
+    invoice_row_factory(
+        invoice=invoice,
+        tenant=tenant,
+        receivable_type=invoicerow_receivable_type,
+        billing_period_start_date=billing_period_start_date,
+        billing_period_end_date=billing_period_end_date,
+        amount=Decimal("111.11"),
+    )
+
+    # When...
+    # Billing contact ends mid-period; no replacement is added.
+    billing_contact.end_date = datetime.date(2026, 12, 15)
+    billing_contact.save()
+
+    sales_order = create_sales_order_with_laske_values(service_unit)
+    adapter = invoice_sales_order_adapter_factory(
+        invoice=invoice,
+        sales_order=sales_order,
+        service_unit=service_unit,
+    )
+
+    # Then...
+    assert adapter.get_contact_to_bill() == tenant_contacts_contact

--- a/laske_export/tests/test_invoice_sales_order_adapter.py
+++ b/laske_export/tests/test_invoice_sales_order_adapter.py
@@ -230,8 +230,12 @@ def test_get_sorted_invoice_rows(exporter_full_test_setup: dict[str, Any]):
     assert sorted_rows == expected_order
 
 
+# =============================================================================
+# Billing contact resolution tests
+# =============================================================================
+
+
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
@@ -239,11 +243,7 @@ def test_get_sorted_invoice_rows(exporter_full_test_setup: dict[str, Any]):
 @pytest.mark.django_db
 def test_get_contact_to_bill_returns_billing_contacts_new_contact(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
-    tenant_contact_factory: Callable[..., TenantContact],
     contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact's contact (laskunsaajan asiakas) is changed to another
@@ -255,12 +255,6 @@ def test_get_contact_to_bill_returns_billing_contacts_new_contact(
     The preferred way is to end the existing billing contact and create a new
     one, which is tested in another test case.
 
-    Given:
-    - billing contact (type=billing),
-    - invoice for this billing contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
-
     When:
     - the billing contact's contact is changed to a new contact,
 
@@ -269,79 +263,19 @@ def test_get_contact_to_bill_returns_billing_contacts_new_contact(
         because they are the designated billing contact for the lease during the
         invoice's billing period.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    # Tenantcontacts that are active for whole year of 2026.
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    original_contact = contact_factory(
-        first_name="Billing", last_name="Contact Original"
-    )
-
-    billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=original_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=original_contact,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    billing_contact: TenantContact = setup["billing_contact"]
+    service_unit: ServiceUnit = setup["service_unit"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
-    new_contact = contact_factory(
-        first_name="Billing",
-        last_name="Contact New",
-    )
+    new_contact = contact_factory(first_name="New", last_name="Billing Contact")
     billing_contact.contact = new_contact
     billing_contact.save()
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
@@ -350,28 +284,15 @@ def test_get_contact_to_bill_returns_billing_contacts_new_contact(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_billing_contact_covers_billing_period_but_ends_afterwards(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
-    tenant_contact_factory: Callable[..., TenantContact],
-    contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact covers the invoice's billing period, but it ends afterwards.
-
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this billing contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
 
     When:
     - billing contact ends after the billing period,
@@ -380,61 +301,11 @@ def test_get_contact_to_bill_when_billing_contact_covers_billing_period_but_ends
     - get_contact_to_bill() should return the billing contact's contact, because
         they are still responsible for the invoice's billing period.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    billing_contact_person = contact_factory(first_name="Billing", last_name="Contact")
-    billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=billing_contact_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=billing_contact_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    billing_contact: TenantContact = setup["billing_contact"]
+    original_billing_contacts_contact: Contact = setup["billing_contacts_contact"]
+    service_unit: ServiceUnit = setup["service_unit"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     billing_contact.end_date = datetime.date(2027, 1, 31)
@@ -442,18 +313,15 @@ def test_get_contact_to_bill_when_billing_contact_covers_billing_period_but_ends
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    assert adapter.get_contact_to_bill() == billing_contact_person
+    assert adapter.get_contact_to_bill() == original_billing_contacts_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
@@ -463,8 +331,6 @@ def test_get_contact_to_bill_when_no_active_tenants(
     tenant_factory: Callable[..., Tenant],
     tenant_contact_factory: Callable[..., TenantContact],
     contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Invoice was created for a tenant, but afterwards that tenant was ended.
@@ -478,14 +344,6 @@ def test_get_contact_to_bill_when_no_active_tenants(
     conditions are likely different from the previous tenant's conditions, which
     means the existing invoice's contents might not be valid anymore.
 
-    Given:
-    - tenant,
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this billing contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
-
     When:
     - the tenant ends (== tenantcontact of type=tenant ends),
     - billing contact ends,
@@ -495,83 +353,27 @@ def test_get_contact_to_bill_when_no_active_tenants(
     - get_contact_to_bill() should return the invoice's original recipient,
       because any changes cannot be automatically handled at this point.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    original_tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    # Tenantcontacts that are active for whole year of 2026.
-    tenant_contacts_contact = contact_factory(
-        first_name="Original Tenant", last_name="Contact"
-    )
-    original_tenant_contact = tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=original_tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    original_contact = contact_factory(
-        first_name="Original Billing", last_name="Contact"
-    )
-    original_billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=original_tenant,
-        contact=original_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=original_contact,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=original_tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    lease: Lease = setup["lease"]
+    service_unit: ServiceUnit = setup["service_unit"]
+    tenant_contact: TenantContact = setup["tenant_contact"]
+    billing_contact: TenantContact = setup["billing_contact"]
+    original_billing_contacts_contact: Contact = setup["billing_contacts_contact"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # Old tenant is ended before invoice's billing period
-    original_tenant_contact.end_date = datetime.date(2026, 11, 30)
-    original_tenant_contact.save()
-    original_billing_contact.end_date = datetime.date(2026, 11, 30)
-    original_billing_contact.save()
+    tenant_contact.end_date = datetime.date(2026, 11, 30)
+    tenant_contact.save()
+    billing_contact.end_date = datetime.date(2026, 11, 30)
+    billing_contact.save()
 
     # New tenant starts during invoice's billing period.
     new_tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
+        lease=lease, share_numerator=1, share_denominator=1, reference=None
     )
     new_tenant_contacts_contact = contact_factory(
-        first_name="New Tenant", last_name="Contact"
+        first_name="New", last_name="Tenant Contact"
     )
     tenant_contact_factory(
         type=TenantContactType.TENANT,
@@ -580,8 +382,7 @@ def test_get_contact_to_bill_when_no_active_tenants(
         start_date=datetime.date(2026, 12, 1),
     )
     new_billing_contacts_contact = contact_factory(
-        first_name="New Billing",
-        last_name="Contact",
+        first_name="New", last_name="Billing Contact"
     )
     tenant_contact_factory(
         type=TenantContactType.BILLING,
@@ -589,43 +390,31 @@ def test_get_contact_to_bill_when_no_active_tenants(
         contact=new_billing_contacts_contact,
         start_date=datetime.date(2026, 12, 1),
     )
+
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
     assert adapter.get_contact_to_bill() == invoice.recipient
-    assert invoice.recipient == original_contact
+    assert invoice.recipient == original_billing_contacts_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_billing_contact_ends_but_another_billing_contact_covers_billing_period(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
     tenant_contact_factory: Callable[..., TenantContact],
     contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact is ended before the invoice's billing period.
           There is another billing contact.
-
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this billing contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
 
     When:
     - billing contact ends before the invoice's billing period,
@@ -636,114 +425,47 @@ def test_get_contact_to_bill_when_billing_contact_ends_but_another_billing_conta
       because they are the designated billing contact for the lease during the
       invoice's billing period.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    original_billing_person = contact_factory(
-        first_name="Billing Original", last_name="Contact"
-    )
-    original_billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=original_billing_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026, originally issued to the active billing contact.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=original_billing_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    tenant: Tenant = setup["tenant"]
+    service_unit: ServiceUnit = setup["service_unit"]
+    billing_contact: TenantContact = setup["billing_contact"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # Original billing contact is ended before the billing period.
-    original_billing_contact.end_date = datetime.date(2026, 11, 30)
-    original_billing_contact.save()
+    billing_contact.end_date = datetime.date(2026, 11, 30)
+    billing_contact.save()
 
     # A new billing contact is added that covers the billing period.
-    new_billing_person = contact_factory(first_name="Billing New", last_name="Contact")
+    new_contact = contact_factory(first_name="New", last_name="Billing Contact")
     tenant_contact_factory(
         type=TenantContactType.BILLING,
         tenant=tenant,
-        contact=new_billing_person,
+        contact=new_contact,
         start_date=datetime.date(2026, 12, 1),
     )
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    assert adapter.get_contact_to_bill() == new_billing_person
+    assert adapter.get_contact_to_bill() == new_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_billing_contact_ends_but_tenant_contact_covers_billing_period(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
-    tenant_contact_factory: Callable[..., TenantContact],
-    contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact is ended before the invoice's billing period.
           No other billing contacts remain. Only the tenant contact remains.
-
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this billing contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
 
     When:
     - billing contact ends before the invoice's billing period,
@@ -755,62 +477,11 @@ def test_get_contact_to_bill_when_billing_contact_ends_but_tenant_contact_covers
       because they are the main responsible party for the lease during the
       invoice's billing period when no billing contacts are active.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    # Tenant contact: active throughout 2026 and beyond.
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    original_billing_person = contact_factory(first_name="Billing", last_name="Contact")
-    billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=original_billing_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026, originally issued to the active billing contact.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=original_billing_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    service_unit: ServiceUnit = setup["service_unit"]
+    billing_contact: TenantContact = setup["billing_contact"]
+    original_tenant_contacts_contact: Contact = setup["tenant_contacts_contact"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # Billing contact is ended before the billing period; no new billing contact is added.
@@ -819,30 +490,22 @@ def test_get_contact_to_bill_when_billing_contact_ends_but_tenant_contact_covers
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    # get_billing_tenantcontacts finds no billing contacts for Dec → falls back to tenant contacts.
-    assert adapter.get_contact_to_bill() == tenant_contacts_contact
+    # No billing contacts for Dec → falls back to tenant contacts.
+    assert adapter.get_contact_to_bill() == original_tenant_contacts_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_billing_contact_ends_and_no_other_contacts_exist(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
-    tenant_contact_factory: Callable[..., TenantContact],
-    contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact is ended before the invoice's billing period.
@@ -852,13 +515,6 @@ def test_get_contact_to_bill_when_billing_contact_ends_and_no_other_contacts_exi
     least one active tenant contact for the lease, but it is technically
     possible.
 
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this billing contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
-
     When:
     - billing contact ends before the invoice's billing period,
     - no active billing contacts remain,
@@ -867,63 +523,13 @@ def test_get_contact_to_bill_when_billing_contact_ends_and_no_other_contacts_exi
     Then:
     - get_contact_to_bill() should return the invoice's original recipient,
         because there are no other contacts to send the invoice to.
-
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    tenant_contact = tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    original_billing_person = contact_factory(first_name="Billing", last_name="Contact")
-    billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=original_billing_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026, originally issued to the active billing contact.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=original_billing_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    service_unit: ServiceUnit = setup["service_unit"]
+    billing_contact: TenantContact = setup["billing_contact"]
+    original_billing_contacts_contact: Contact = setup["billing_contacts_contact"]
+    tenant_contact: TenantContact = setup["tenant_contact"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # Both billing and tenant contacts are ended before the billing period.
@@ -934,43 +540,29 @@ def test_get_contact_to_bill_when_billing_contact_ends_and_no_other_contacts_exi
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    # get_billing_tenantcontacts finds no billing contacts → falls back to tenant contacts → also none.
-    # Falls through to invoice.recipient.
+    # No billing contacts → no tenant contacts → falls through to invoice.recipient.
     assert adapter.get_contact_to_bill() == invoice.recipient
-    assert invoice.recipient == original_billing_person
+    assert invoice.recipient == original_billing_contacts_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_newer_billing_contact_covers_billing_period_and_another_begins_midway(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
     tenant_contact_factory: Callable[..., TenantContact],
     contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact covers the entire billing period, but another billing
     contact begins midway through the invoice's billing period.
-
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
 
     When:
     - billing contact covers the billing period,
@@ -981,113 +573,45 @@ def test_get_contact_to_bill_when_newer_billing_contact_covers_billing_period_an
       because it is responsible for part of the invoice's billing period, and
       newer contacts are preferred over older contacts.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    older_billing_person = contact_factory(
-        first_name="Billing Older", last_name="Contact"
-    )
-    # Billing contact at invoice creation time: active from Jan 1, no end date.
-    tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=older_billing_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026, originally issued to the active billing contact.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=older_billing_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    tenant: Tenant = setup["tenant"]
+    service_unit: ServiceUnit = setup["service_unit"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # A newer billing contact is added that starts midway through the billing period.
-    newer_billing_person = contact_factory(
-        first_name="Billing Newer", last_name="Contact"
-    )
+    new_contact = contact_factory(first_name="New", last_name="Billing Contact")
     tenant_contact_factory(
         type=TenantContactType.BILLING,
         tenant=tenant,
-        contact=newer_billing_person,
+        contact=new_contact,
         start_date=datetime.date(2026, 12, 15),
     )
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    # get_billing_tenantcontacts returns both, ordered by -start_date → newer (Dec 15) is first.
-    assert adapter.get_contact_to_bill() == newer_billing_person
+    # Both billing contacts overlap Dec; ordered by -start_date → newer (Dec 15) is first.
+    assert adapter.get_contact_to_bill() == new_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and_another_begins(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
     tenant_contact_factory: Callable[..., TenantContact],
     contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
-    Case: Billing contact ends during the invoice's billing period, but another billing contact begins.
-
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
+    Case: Billing contact ends during the invoice's billing period, but another
+    billing contact begins.
 
     When:
     - billing contact ends during the invoice's billing period,
@@ -1098,117 +622,47 @@ def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and
       because it is responsible for part of the invoice's billing period, and
       newer contacts are preferred over older contacts.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    original_billing_person = contact_factory(
-        first_name="Billing Original", last_name="Contact"
-    )
-    # Billing contact at invoice creation time: active from Jan 1, no end date.
-    original_billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=original_billing_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026, originally issued to the active billing contact.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=original_billing_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    tenant: Tenant = setup["tenant"]
+    service_unit: ServiceUnit = setup["service_unit"]
+    billing_contact: TenantContact = setup["billing_contact"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # Original billing contact ends mid-period; a newer billing contact picks up immediately.
-    original_billing_contact.end_date = datetime.date(2026, 12, 15)
-    original_billing_contact.save()
+    billing_contact.end_date = datetime.date(2026, 12, 15)
+    billing_contact.save()
 
-    newer_billing_person = contact_factory(
-        first_name="Billing Newer", last_name="Contact"
-    )
+    new_contact = contact_factory(first_name="New", last_name="Billing Contact")
     tenant_contact_factory(
         type=TenantContactType.BILLING,
         tenant=tenant,
-        contact=newer_billing_person,
+        contact=new_contact,
         start_date=datetime.date(2026, 12, 16),
     )
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    # Both billing contacts overlap the Dec period; ordered by -start_date → newer (Dec 16) is first.
-    assert adapter.get_contact_to_bill() == newer_billing_person
+    # Both billing contacts overlap Dec; ordered by -start_date → newer (Dec 16) is first.
+    assert adapter.get_contact_to_bill() == new_contact
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    # Pass the ID to the test setup fixture
     "invoice_sales_order_adapter_billing_contact_test_setup",
     [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
     indirect=True,
 )
 def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and_only_tenant_contact_remains(
     invoice_sales_order_adapter_billing_contact_test_setup: dict[str, Any],
-    tenant_factory: Callable[..., Tenant],
-    tenant_contact_factory: Callable[..., TenantContact],
-    contact_factory: Callable[..., Contact],
-    invoice_factory: Callable[..., Invoice],
-    invoice_row_factory: Callable[..., InvoiceRow],
 ):
     """
     Case: Billing contact ends during the invoice's billing period.
           No other billing contacts remain. Only the tenant contact remains.
-
-    Given:
-    - tenant contact (type=tenant),
-    - billing contact (type=billing),
-    - invoice for this contact,
-    - invoice rows for this tenant,
-    - billing period when the contacts are active,
 
     When:
     - billing contact ends during the invoice's billing period,
@@ -1222,63 +676,11 @@ def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and
       The tenant contact is the main responsible party for the lease during the
       invoice's billing period.
     """
-    # Given...
-    lease: Lease = invoice_sales_order_adapter_billing_contact_test_setup["lease"]
-    service_unit: ServiceUnit = invoice_sales_order_adapter_billing_contact_test_setup[
-        "service_unit"
-    ]
-
-    tenant = tenant_factory(
-        lease=lease,
-        share_numerator=1,
-        share_denominator=1,
-        reference=None,
-    )
-
-    tenant_contacts_contact = contact_factory(first_name="Tenant", last_name="Contact")
-    # Tenant contact: active throughout the billing period.
-    tenant_contact_factory(
-        type=TenantContactType.TENANT,
-        tenant=tenant,
-        contact=tenant_contacts_contact,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    billing_contact_person = contact_factory(first_name="Billing", last_name="Contact")
-    # Billing contact at invoice creation time: active from Jan 1, no end date.
-    billing_contact = tenant_contact_factory(
-        type=TenantContactType.BILLING,
-        tenant=tenant,
-        contact=billing_contact_person,
-        start_date=datetime.date(2026, 1, 1),
-    )
-
-    # Invoice for December 2026, originally issued to the active billing contact.
-    billing_period_start_date = datetime.date(year=2026, month=12, day=1)
-    billing_period_end_date = datetime.date(year=2026, month=12, day=31)
-
-    invoice = invoice_factory(
-        lease=lease,
-        total_amount=Decimal("111.11"),
-        billed_amount=Decimal("111.11"),
-        outstanding_amount=Decimal("111.11"),
-        recipient=billing_contact_person,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-    )
-    invoicerow_receivable_type: ReceivableType = (
-        invoice_sales_order_adapter_billing_contact_test_setup[
-            "invoicerow_receivable_type"
-        ]
-    )
-    invoice_row_factory(
-        invoice=invoice,
-        tenant=tenant,
-        receivable_type=invoicerow_receivable_type,
-        billing_period_start_date=billing_period_start_date,
-        billing_period_end_date=billing_period_end_date,
-        amount=Decimal("111.11"),
-    )
+    setup = invoice_sales_order_adapter_billing_contact_test_setup
+    service_unit: ServiceUnit = setup["service_unit"]
+    billing_contact: TenantContact = setup["billing_contact"]
+    original_tenant_contacts_contact: Contact = setup["tenant_contacts_contact"]
+    invoice: Invoice = setup["invoice"]
 
     # When...
     # Billing contact ends mid-period; no replacement is added.
@@ -1287,10 +689,8 @@ def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and
 
     sales_order = create_sales_order_with_laske_values(service_unit)
     adapter = invoice_sales_order_adapter_factory(
-        invoice=invoice,
-        sales_order=sales_order,
-        service_unit=service_unit,
+        invoice=invoice, sales_order=sales_order, service_unit=service_unit
     )
 
     # Then...
-    assert adapter.get_contact_to_bill() == tenant_contacts_contact
+    assert adapter.get_contact_to_bill() == original_tenant_contacts_contact

--- a/laske_export/tests/test_invoice_sales_order_adapter.py
+++ b/laske_export/tests/test_invoice_sales_order_adapter.py
@@ -694,3 +694,98 @@ def test_get_contact_to_bill_when_billing_contact_ends_during_billing_period_and
 
     # Then...
     assert adapter.get_contact_to_bill() == original_tenant_contacts_contact
+
+
+# =============================================================================
+# Update invoice recipient tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "exporter_lacking_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_update_invoice_recipient_if_changed_when_recipient_is_none(
+    exporter_lacking_test_setup: dict[str, Any],
+):
+    """
+    When:
+    - contact_to_be_billed is None,
+
+    Then:
+    - method should return early without updating the invoice recipient,
+    - a warning should be logged.
+    """
+    adapter: InvoiceSalesOrderAdapter = exporter_lacking_test_setup["adapter"]
+    invoice: Invoice = exporter_lacking_test_setup["invoice1"]
+    original_recipient = invoice.recipient
+
+    # When...
+    adapter._update_invoice_recipient_if_changed(None)  # type: ignore[call-arg]
+
+    # Then...
+    invoice.refresh_from_db()
+    assert invoice.recipient == original_recipient
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "exporter_lacking_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_update_invoice_recipient_if_changed_when_recipient_is_same(
+    exporter_lacking_test_setup: dict[str, Any],
+):
+    """
+    When:
+    - contact_to_be_billed is the same as invoice.recipient,
+
+    Then:
+    - method should not save the invoice, as nothing changed.
+    """
+    adapter: InvoiceSalesOrderAdapter = exporter_lacking_test_setup["adapter"]
+    invoice: Invoice = exporter_lacking_test_setup["invoice1"]
+    original_recipient = invoice.recipient
+
+    # When...
+    adapter._update_invoice_recipient_if_changed(original_recipient)
+
+    # Then...
+    invoice.refresh_from_db()
+    assert invoice.recipient == original_recipient
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "exporter_lacking_test_setup",
+    [ServiceUnitId.MAKE, ServiceUnitId.KAMA],
+    indirect=True,
+)
+def test_update_invoice_recipient_if_changed_when_recipient_is_different(
+    exporter_lacking_test_setup: dict[str, Any],
+    contact_factory: Callable[..., Contact],
+):
+    """
+    When:
+    - contact_to_be_billed is different from invoice.recipient,
+
+    Then:
+    - method should update invoice.recipient to the new contact,
+    - invoice should be saved,
+    - an info log should be created.
+    """
+    adapter: InvoiceSalesOrderAdapter = exporter_lacking_test_setup["adapter"]
+    invoice: Invoice = exporter_lacking_test_setup["invoice1"]
+    original_recipient = invoice.recipient
+
+    # When...
+    new_contact = contact_factory(first_name="New", last_name="Contact")
+    adapter._update_invoice_recipient_if_changed(new_contact)
+
+    # Then...
+    invoice.refresh_from_db()
+    assert invoice.recipient == new_contact
+    assert invoice.recipient != original_recipient

--- a/leasing/models/tenant.py
+++ b/leasing/models/tenant.py
@@ -60,6 +60,10 @@ class Tenant(TimeStampedSafeDeleteModel):
         start_date: datetime.date,
         end_date: datetime.date | None,
     ) -> QuerySet["TenantContact"]:
+        """
+        Returns tenant contacts of the given type for the given period, sorted
+        by start_date descending
+        """
         if not end_date:
             range_filter = Q(Q(end_date=None) | Q(end_date__gte=start_date))
         else:

--- a/leasing/models/tenant.py
+++ b/leasing/models/tenant.py
@@ -58,7 +58,7 @@ class Tenant(TimeStampedSafeDeleteModel):
         self,
         contact_type: TenantContactType,
         start_date: datetime.date,
-        end_date: datetime.date,
+        end_date: datetime.date | None,
     ) -> QuerySet["TenantContact"]:
         if not end_date:
             range_filter = Q(Q(end_date=None) | Q(end_date__gte=start_date))
@@ -77,15 +77,19 @@ class Tenant(TimeStampedSafeDeleteModel):
         return tenantcontacts
 
     def get_tenant_tenantcontacts(
-        self, start_date: datetime.date, end_date: datetime.date
-    ):
+        self, start_date: datetime.date, end_date: datetime.date | None
+    ) -> QuerySet["TenantContact"]:
         return self.get_tenantcontacts_for_period(
             TenantContactType.TENANT, start_date, end_date
         )
 
     def get_billing_tenantcontacts(
-        self, start_date: datetime.date, end_date: datetime.date
+        self, start_date: datetime.date, end_date: datetime.date | None
     ) -> QuerySet["TenantContact"]:
+        """
+        Returns billing-type contacts for the tenant for the given period, if available.
+        If not available, returns tenant-type contacts for the same period.
+        """
         billing_contacts = self.get_tenantcontacts_for_period(
             TenantContactType.BILLING, start_date, end_date
         )

--- a/leasing/models/types.py
+++ b/leasing/models/types.py
@@ -80,7 +80,7 @@ class InvoiceDatum(TypedDict):
     service_unit: "ServiceUnit"
     generated: bool
     invoicing_date: datetime.date
-    invoiceset: "InvoiceSet"
+    invoiceset: "InvoiceSet | None"
     outstanding_amount: Decimal
 
 


### PR DESCRIPTION
## Update invoice.receiver to be the same as is sent to SAP

This helps keep MVJ and SAP in sync with the same billing information.

## Send invoice to main tenantcontact, if billing contact ends during billing

If the most recent billing contact ends during the billing period, and
no other billing contact covers the end of the period, send the invoice
to tenant contact (type=tenant) instead.

This solves the problem of sending invoices to an accounting office that
is no longer serving the customer, avoiding lengthy investigation and
possibly delayed or forgotten invoices.

## Minor improvements

* Improve variable semantics, type hints, and docstrings for related code.
* Sanitize `leasing_tenant.reference`, because I discovered that people sometimes write personal names in that field.
