### PR TITLE
Use stable reference for image URL for management pod

### DIFF
--- a/Dockerfile.management
+++ b/Dockerfile.management
@@ -19,7 +19,7 @@ USER root
 
 # Install PostgreSQL 17 client tools (pg_dump, pg_restore, psql).
 # The default UBI9 AppStream only ships PG13; use the PGDG repo to get PG17.
-RUN dnf install -y https://ftp.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-42.0-64.rhel9PGDG.noarch.rpm \
+RUN dnf install -y https://ftp.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && dnf install -y postgresql17 \
     && dnf clean all
 


### PR DESCRIPTION
The Red Hat PostgreSQL repository seems to remove historical versions after the newer one is published; e.g. 42.0-64 in favor of 42.0-66. This makes the `latest` the only stable tag available.