### PR TITLE
fix statfin consumer price index API calls

### DIFF
--- a/leasing/management/commands/import_index.py
+++ b/leasing/management/commands/import_index.py
@@ -9,25 +9,25 @@ from leasing.models.rent import LegacyIndex
 INDEX_IMPORTS = [
     {
         "name": "Elinkustannusindeksi 1951:100 (kuukasittaiset)",
-        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xl.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/11xl.px",
     },
     {
         "name": "Elinkustannusindeksi 1951:100 (vuosittaiset)",
-        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xm.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/11xm.px",
     },
     {
         "name": "Elinkustannusindeksi 1938:8-1939:7 = 100 (kuukausittaiset)",
-        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xn.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/11xn.px",
         "legacy": "number_1938",
     },
     {
         "name": "Elinkustannusindeksi 1938:8-1939:7 = 100 (vuosittaiset)",
-        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xp.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/11xp.px",
         "legacy": "number_1938",
     },
     {
         "name": "Elinkustannusindeksi 1914:1-6 = 100 (vuosittaiset)",
-        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/statfin_khi_pxt_11xy.px",
+        "url": "https://statfin.stat.fi/PXWeb/api/v1/fi/StatFin/11xy.px",
         "legacy": "number_1914",
     },
 ]

--- a/leasing/management/commands/import_periodic_rent_adjustment_index.py
+++ b/leasing/management/commands/import_periodic_rent_adjustment_index.py
@@ -110,7 +110,7 @@ INDEXES_TO_IMPORT: list[IndexInput] = [
             "13mq -- Price index of old dwellings in housing companies (2020=100) "
             "and numbers of transactions, yearly, 2020-2023"
         ),
-        "url": "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/statfin_ashi_pxt_13mq.px",
+        "url": "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/13mq.px",
         "code": "ketj_P_QA_T",
     },
 ]
@@ -150,15 +150,15 @@ def _get_index_data(url: str, code: str) -> ResponseData:
 
     Example CURL command how to get the data manually:
 
-curl -X POST "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/statfin_ashi_pxt_13mq.px" \
+curl -X POST "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/13mq.px" \
 -d  '{
         "query": [
             {
-                "code":"Alue",
+                "code":"alue_43_20220407",
                 "selection":{"filter":"item","values":["pks"]}
             },
             {
-                "code":"Tiedot",
+                "code":"contentscode",
                 "selection":{"filter":"item","values":["ketj_P_QA_T"]}
             }
         ],
@@ -170,11 +170,11 @@ curl -X POST "https://pxdata.stat.fi:443/PxWeb/api/v1/fi/StatFin/ashi/statfin_as
         code: Identifier for the price index column.
     """
     filter_greater_helsinki_area = {
-        "code": "Alue",
+        "code": "alue_43_20220407",
         "selection": {"filter": "item", "values": ["pks"]},
     }
     filter_price_index = {
-        "code": "Tiedot",
+        "code": "contentscode",
         "selection": {"filter": "item", "values": [code]},
     }
     query = {
@@ -201,8 +201,8 @@ def _check_that_response_data_is_valid(
     """
     columns = index_data.get("columns", [])
     try:
-        _find_key_position(columns, "Vuosi")
-        _find_key_position(columns, "Alue")
+        _find_key_position(columns, "timeperiod_y")
+        _find_key_position(columns, "alue_43_20220407")
         _find_column_position(columns, index_input["code"])
         _find_value_position(columns, index_input["code"])
     except ResponseDataError as e:
@@ -338,9 +338,9 @@ def _update_or_create_point_figures(
         Count of updated point figures, and count of created point figures.
     """
     columns = index_data.get("columns", [])
-    year_key_pos = _find_key_position(columns, "Vuosi")
+    year_key_pos = _find_key_position(columns, "timeperiod_y")
     figure_value_pos = _find_value_position(columns, index_input["code"])
-    region_key_pos = _find_key_position(columns, "Alue")
+    region_key_pos = _find_key_position(columns, "alue_43_20220407")
 
     data_points = index_data.get("data", [])
     comments = index_data.get("comments", [])

--- a/leasing/tests/management/commands/test_import_periodic_rent_adjustment_index.py
+++ b/leasing/tests/management/commands/test_import_periodic_rent_adjustment_index.py
@@ -52,8 +52,8 @@ def test_missing_column_raises(real_input_data: IndexInput, real_data: ResponseD
 
 def test_key_position_found(columns_real_data: list[ColumnItem]):
     """Happy path: key positions are correctly identified in the data."""
-    assert _find_key_position(columns_real_data, "Vuosi") == 0
-    assert _find_key_position(columns_real_data, "Alue") == 1
+    assert _find_key_position(columns_real_data, "timeperiod_y") == 0
+    assert _find_key_position(columns_real_data, "alue_43_20220407") == 1
 
 
 def test_key_column_missing_code_raises(
@@ -65,7 +65,7 @@ def test_key_column_missing_code_raises(
         column["code"] = "Something else"
 
     with pytest.raises(ResponseDataError):
-        _find_key_position(columns, "Vuosi")
+        _find_key_position(columns, "timeperiod_y")
 
 
 def test_key_column_wrong_type_raises(
@@ -78,7 +78,7 @@ def test_key_column_wrong_type_raises(
         column["type"] = "c"
 
     with pytest.raises(ResponseDataError):
-        _find_key_position(columns, "Vuosineljännes")
+        _find_key_position(columns, "timeperiod_q")
 
 
 def test_value_position_found(
@@ -243,12 +243,12 @@ def test_create_or_update_point_figure(
         {
             "columns": [
                 {
-                    "code": "Vuosi",
+                    "code": "timeperiod_y",
                     "text": "",
                     "comment": "",
                     "type": "t",
                 },
-                {"code": "Alue", "text": "", "type": "d"},
+                {"code": "alue_43_20220407", "text": "", "type": "d"},
                 {
                     "code": "test_index_code_1",
                     "text": "",
@@ -307,12 +307,12 @@ def test_skip_preliminary_point_figures(
         {
             "columns": [
                 {
-                    "code": "Vuosi",
+                    "code": "timeperiod_y",
                     "text": "",
                     "comment": "",
                     "type": "t",
                 },
-                {"code": "Alue", "text": "", "type": "d"},
+                {"code": "alue_43_20220407", "text": "", "type": "d"},
                 {
                     "code": "test_index_code_1",
                     "text": "",
@@ -322,12 +322,12 @@ def test_skip_preliminary_point_figures(
             ],
             "comments": [
                 {
-                    "variable": "Vuosi",
+                    "variable": "timeperiod_y",
                     "value": "2023",
                     "comment": "* ennakkotieto\r\n",
                 },
                 {
-                    "variable": "Vuosi",
+                    "variable": "timeperiod_y",
                     "value": "2024",
                     "comment": "* ennakkotieto\r\n",
                 },
@@ -363,7 +363,7 @@ def real_input_data() -> IndexInput:
     return {
         "name": "13mq -- Vanhojen osakeasuntojen hintaindeksi (2020=100) ja \
                 kauppojen lukumäärät, vuositasolla, 2020-2023",
-        "url": "https://pxdata.stat.fi:443/PxWeb/api/v1/en/StatFin/ashi/statfin_ashi_pxt_13mq.px",
+        "url": "https://pxdata.stat.fi:443/PxWeb/api/v1/en/StatFin/ashi/13mq.px",
         "code": "ketj_P_QA_T",
     }
 
@@ -372,8 +372,8 @@ def real_input_data() -> IndexInput:
 def columns_real_data() -> list[ColumnItem]:
     """Column items from real API response data."""
     return [
-        {"code": "Vuosi", "text": "Year", "type": "t"},
-        {"code": "Alue", "text": "Region", "type": "d"},
+        {"code": "timeperiod_y", "text": "Year", "type": "t"},
+        {"code": "alue_43_20220407", "text": "Region", "type": "d"},
         {
             "code": "ketj_P_QA_T",
             "text": "Index (2020=100)",
@@ -394,12 +394,12 @@ def comments_test_data() -> list[CommentItem]:
     """Hypothetical comment items."""
     return [
         {
-            "variable": "Vuosi",
+            "variable": "timeperiod_y",
             "value": "2022",
             "comment": "* preliminary data\r\n",
         },
         {
-            "variable": "Vuosi",
+            "variable": "timeperiod_y",
             "value": "2023",
             "comment": "* preliminary data\r\n",
         },


### PR DESCRIPTION
according to changes to statfin announced changes in paths that were shortened: https://stat.fi/fi/palvelut/tilastodatapalvelut/avoin-data-ja-rajapinnat/tietokantojen-rajapintakaytto/api-kyselyjen-muutosohje